### PR TITLE
result/s typo fix; rename subbundles -> patches

### DIFF
--- a/bin/spex
+++ b/bin/spex
@@ -208,16 +208,16 @@ def main(args=None):
         spot_nx, spot_ny = spots.shape[2:4]
 
         #- Organize what sub-bundle patches to extract
-        subbundles = list()
+        patches = list()
         subbundlesize = args.bundlesize // args.nsubbundles
         for ispec in range(bspecmin, bspecmin+args.bundlesize, subbundlesize):
             for iwave in range(wavepad, wavepad+nwave, args.nwavestep):
-                subbundles.append((ispec, iwave))
+                patches.append((ispec, iwave))
 
         #- place to keep extraction patch results before assembling in rank 0
         results = list()
 
-        for ispec, iwave in subbundles[rank::size]:
+        for ispec, iwave in patches[rank::size]:
             log.debug(f'rank={rank}, ispec={ispec}, iwave={iwave}')
             
             #- Always extract the same patch size (more efficient for GPU
@@ -243,7 +243,7 @@ def main(args=None):
                 allresults.extend(rr)
 
             #- Now put these into the final arrays
-            for ispec, iwave, results in allresults:
+            for ispec, iwave, result in allresults:
                 fx = result['flux']
                 fxivar = result['ivar']
                 xRdiags = result['Rdiags']

--- a/bin/spex
+++ b/bin/spex
@@ -209,8 +209,8 @@ def main(args=None):
 
         #- Organize what sub-bundle patches to extract
         patches = list()
-        subbundlesize = args.bundlesize // args.nsubbundles
-        for ispec in range(bspecmin, bspecmin+args.bundlesize, subbundlesize):
+        nspectra_per_patch = args.bundlesize // args.nsubbundles
+        for ispec in range(bspecmin, bspecmin+args.bundlesize, nspectra_per_patch):
             for iwave in range(wavepad, wavepad+nwave, args.nwavestep):
                 patches.append((ispec, iwave))
 
@@ -224,7 +224,7 @@ def main(args=None):
             #- memory transfer) then decide post-facto whether to keep it all
 
             result = ex2d_padded(image, imageivar,
-                                 ispec-bspecmin, subbundlesize,
+                                 ispec-bspecmin, nspectra_per_patch,
                                  iwave, args.nwavestep,
                                  spots, corners,
                                  wavepad=wavepad,
@@ -248,10 +248,10 @@ def main(args=None):
                 fxivar = result['ivar']
                 xRdiags = result['Rdiags']
 
-                assert fx.shape == (subbundlesize, args.nwavestep)
+                assert fx.shape == (nspectra_per_patch, args.nwavestep)
 
                 #- put the extracted patch into the final output arrays
-                specslice = np.s_[ispec-args.specmin:ispec-args.specmin+subbundlesize]
+                specslice = np.s_[ispec-args.specmin:ispec-args.specmin+nspectra_per_patch]
                 waveslice = np.s_[iwave-wavepad:iwave-wavepad+args.nwavestep]
 
                 nwavekeep = min(nwave - (iwave-wavepad), args.nwavestep)


### PR DESCRIPTION
This PR
  1. fixes a `results` vs. `result` typo that @dmargala found and mentioned in issue #6 (thanks!)
  2. renames the `subbundles` list to `patches` based upon the code walk through discussion.

I'm still chasing upstream inconsistencies with specter, but item (1) definitely is needed for final compatibility so thanks for catching that before I tripped on it.