### PR TITLE
fix spots, add unit tests

### DIFF
--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -258,7 +258,7 @@ def projection_matrix(ispec, nspec, iwave, nwave, spots, corners):
         spots: 4D array[ispec, iwave, ny, nx] of PSF spots
         corners: (xc,yc) where each is 2D array[ispec,iwave] lower left corner of spot
 
-    Returns 4D A[iy, ix, ispec, iwave] projection matrix
+    Returns (A[iy, ix, ispec, iwave], (xmin, xmax, ymin, ymax))
 
     Cast to 2D for using with linear algebra:
 

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -1,0 +1,80 @@
+import unittest, os, shutil, uuid
+import pkg_resources
+from astropy.table import Table
+import numpy as np
+
+from gpu_specter.io import read_psf
+from gpu_specter.extract.cpu import projection_matrix, get_spots
+
+try:
+    import specter.psf
+    specter_available = True
+except ImportError:
+    specter_available = False
+
+class TestProjectionMatrix(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.psffile = pkg_resources.resource_filename(
+            'gpu_specter', 'test/data/psf-r0-00051060.fits')
+        cls.psfdata = read_psf(cls.psffile)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_basics(self):
+        wavelengths = np.arange(6000.0, 6050.0, 1.0)
+        spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
+        
+        #- Projection matrix for a subset of spots and wavelenghts
+        A4, (xmin, xmax, ymin, ymax) = projection_matrix(
+            ispec=0, nspec=5, iwave=0, nwave=25, spots=spots, corners=corners)
+        self.assertEqual(A4.shape[2:4], (5,25))
+        self.assertEqual(A4.shape[0:2], (ymax-ymin, xmax-xmin))
+
+        #- Another subset using same spots, but not starting from (0,0)
+        A4, (xmin, xmax, ymin, ymax) = projection_matrix(
+            ispec=10, nspec=5, iwave=20, nwave=25, spots=spots, corners=corners)
+        self.assertEqual(A4.shape[2:4], (5,25))
+        self.assertEqual(A4.shape[0:2], (ymax-ymin, xmax-xmin))
+
+    @unittest.skipIf(not specter_available, 'specter not available')
+    def test_compare_specter(self):
+        
+        #- gpu_specter
+        wavelengths = np.arange(6000.0, 6050.0, 1.0)
+        spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
+
+        #- Load specter PSF
+        psf = specter.psf.load_psf(self.psffile)
+        
+        #- Compare projection matrix for a few combos of spectra & waves
+        for ispec, nspec, iwave, nwave in (
+            (0, 5, 0, 25),
+            (10, 5, 20, 25),
+            (7, 3, 10, 12),
+            ):
+        
+            A4, xyrange = projection_matrix(
+                ispec=ispec, nspec=nspec, iwave=iwave, nwave=nwave,
+                spots=spots, corners=corners)
+            A2 = A4.reshape(A4.shape[0]*A4.shape[1], A4.shape[2]*A4.shape[3])
+
+            #- Specter
+            A = psf.projection_matrix(
+                (ispec, ispec+nspec), wavelengths[iwave:iwave+nwave],
+                xyrange).toarray()
+        
+            self.assertEqual(A.shape, A2.shape)
+            self.assertTrue(np.allclose(A, A2))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/gpu_specter/test/test_psfcoeff.py
+++ b/py/gpu_specter/test/test_psfcoeff.py
@@ -40,7 +40,7 @@ class TestPSFCoeff(unittest.TestCase):
         #- wavelengths outside original range are allowed
         meta = psfdata['PSF'].meta
         nwave = 30
-        wavelengths = np.linspace(meta['WAVEMIN']-10, meta['WAVEMAX']+10, 30)
+        wavelengths = np.linspace(meta['WAVEMIN']-10, meta['WAVEMAX']+10, nwave)
         psfparams = evalcoeffs(psfdata, wavelengths)
         psfparams = evalcoeffs(psfdata, wavelengths, specmin=0, nspec=25)
         self.assertEqual(psfparams['X'].shape, (25, nwave))
@@ -59,7 +59,7 @@ class TestPSFCoeff(unittest.TestCase):
         psf = specter.psf.load_psf(self.psffile)
         iispec = np.arange(500)
         
-        print('Comparing X and Y')
+        # print('Comparing X and Y')
         self.assertTrue(np.allclose(psf.x(iispec, wavelengths), psfparams['X']))
         self.assertTrue(np.allclose(psf.y(iispec, wavelengths), psfparams['Y']))
 
@@ -67,13 +67,13 @@ class TestPSFCoeff(unittest.TestCase):
         self.assertTrue(len(common_keys) > 0)
         
         for key in common_keys:
-            print(f'Comparing {key}')
+            # print(f'Comparing {key}')
             ok = np.allclose(psfparams[key], psf.coeff[key].eval(iispec, wavelengths))
             self.assertTrue(ok, key)
 
         for i in range(psfparams['GH'].shape[0]):
             for j in range(psfparams['GH'].shape[1]):
-                print(f'Comparing GH-{i}-{j}')
+                # print(f'Comparing GH-{i}-{j}')
                 ok = np.allclose(psfparams['GH'][i,j],
                                  psf.coeff[f'GH-{i}-{j}'].eval(iispec, wavelengths))
                 self.assertTrue(ok, f'GH-{i}-{j}')

--- a/py/gpu_specter/test/test_spots.py
+++ b/py/gpu_specter/test/test_spots.py
@@ -1,0 +1,99 @@
+import unittest, os, shutil, uuid
+import pkg_resources
+from astropy.table import Table
+import numpy as np
+from scipy.ndimage.measurements import center_of_mass
+
+from gpu_specter.io import read_psf
+from gpu_specter.extract.cpu import evalcoeffs, get_spots
+
+try:
+    import specter.psf
+    specter_available = True
+except ImportError:
+    specter_available = False
+
+class TestPSFSpots(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.psffile = pkg_resources.resource_filename(
+            'gpu_specter', 'test/data/psf-r0-00051060.fits')
+        cls.psfdata = read_psf(cls.psffile)
+        meta = cls.psfdata['PSF'].meta
+        nwave = 15
+        cls.wavelengths = np.linspace(meta['WAVEMIN']+100, meta['WAVEMAX']-100, nwave)
+        cls.psfparams = evalcoeffs(cls.psfdata, cls.wavelengths)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_basics(self):
+        nspec = 50
+        spots, corners = get_spots(0, nspec, self.wavelengths, self.psfdata)
+        cx, cy = corners
+        
+        #- Dimensions
+        _nspec, nwave, ny, nx = spots.shape
+        self.assertEqual(_nspec, nspec)
+        self.assertEqual(nwave, len(self.wavelengths))
+        self.assertEqual(cx.shape, (nspec, nwave))
+        self.assertEqual(cy.shape, (nspec, nwave))
+
+        #- Spots should have an odd number of pixels in each dimension so
+        #- that there is a well defined central pixel
+        self.assertEqual(ny%2, 1)
+        self.assertEqual(nx%2, 1)
+        
+        #- positivity and normalization
+        self.assertTrue(np.all(spots >= 0.0))
+        norm = spots.sum(axis=(2,3))
+        self.assertTrue(np.allclose(norm, 1.0))
+
+        #- The PSF centroid should be within that central pixel
+        #- Note: X,Y relative to pixel center, not edge
+        dx = self.psfparams['X'][0:nspec, :] - cx - nx//2
+        dy = self.psfparams['Y'][0:nspec, :] - cy - ny//2
+        
+        self.assertTrue(np.all((-0.5 <= dx) & (dx < 0.5)))
+        self.assertTrue(np.all((-0.5 <= dy) & (dy < 0.5)))
+        
+        #- The actual centroid of the spot should be within that pixel
+        #- Allow some buffer for asymmetric tails
+        for ispec in range(nspec):
+            for iwave in range(len(self.wavelengths)):
+                yy, xx = center_of_mass(spots[ispec, iwave])
+                dx = xx - nx//2
+                dy = yy - ny//2
+                msg = f'ispec={ispec}, iwave={iwave}'
+                self.assertTrue((-0.7 <= dx) and (dx < 0.7), msg + f' dx={dx}')
+                self.assertTrue((-0.7 <= dy) and (dy < 0.7), msg + f' dy={dy}')
+
+    @unittest.skipIf(not specter_available, 'specter not available')
+    def test_compare_specter(self):
+        #- specter version
+        psf = specter.psf.load_psf(self.psffile)
+
+        for ispec in np.linspace(0, 499, 20).astype(int):
+            spots, corners = get_spots(ispec, 1, self.wavelengths, self.psfdata)
+            xc, yc = corners
+
+            ny, nx = spots.shape[2:4]
+
+            for iwave, w in enumerate(self.wavelengths):
+                xslice, yslice, pix = psf.xypix(ispec, w)
+                
+                self.assertEqual(pix.shape, (ny, nx))                
+                self.assertEqual(xc[0, iwave], xslice.start)
+                self.assertEqual(yc[0, iwave], yslice.start)
+                self.assertTrue(np.allclose(spots[0, iwave], pix))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR:
  * adds unit tests for CPU `get_spots` and `projection_matrix`
  * fixes PSF spot evaluation binning bugs
  * fixes PSF spot normalization

Note: unlike what I suggested at our weekly meeting, the spots differences with specter was *not* due to an equivalently correct but different of definition for the corners; it was a bug in gpu_specter that I now fixed.

Tests require specter master, since this work also uncovered a bug there that was fixed in desihub/specter#79.

CPU code in gpu_specter now agrees with specter up through projection_matrix.

Assigning this to @dmargala but also pinging @lastephey and @ziyaointl .