### PR TITLE
Add unit tests for gpu functions

### DIFF
--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -1,0 +1,114 @@
+import numpy as np
+
+try:
+    import cupy as cp
+    cupy_available = True
+except ImportError:
+    cupy_available = False
+
+def xp_deconvolve(pixel_values, pixel_ivar, A):
+    """
+    """
+    try:
+        xp = cp.get_array_module(A)
+    except NameError:
+        #- If the cupy module is unavailble, default to numpy
+        xp = np
+    #- Set up the equation to solve (B&S eq 4)
+    ATNinv = A.T.dot(xp.diag(pixel_ivar))
+    iCov = ATNinv.dot(A)
+    iCov += 1e-12*xp.eye(iCov.shape[0])
+    #- Solve the linear least-squares problem.
+    #- Force rcond to be the same when using cupy/numpy 
+    #- See: https://github.com/numpy/numpy/blob/v1.18.4/numpy/linalg/linalg.py#L2247
+    rcond = np.core.finfo(iCov.dtype).eps * max(iCov.shape)
+    deconvolved, res, rank, sing = xp.linalg.lstsq(iCov, ATNinv.dot(pixel_values), rcond=rcond)
+    if rank < len(deconvolved):
+        print('WARNING: deconvolved inverse-covariance is not positive definite.')
+    return deconvolved, iCov
+
+def xp_decorrelate(iCov):
+    """
+    """
+    try:
+        xp = cp.get_array_module(A)
+    except NameError:
+        # If the cupy module is unavailble, default to numpy
+        xp = np
+    # Calculate the matrix square root of iCov to diagonalize the flux errors.
+    u, v = xp.linalg.eigh((iCov + iCov.T)/2.)
+    # Check that all eigenvalues are positive.
+    assert xp.all(u > 0), 'Found some negative iCov eigenvalues.'
+    # Check that the eigenvectors are orthonormal so that vt.v = 1
+    assert xp.allclose(xp.eye(len(u)), v.T.dot(v))
+    Q = v.dot(xp.diag(xp.sqrt(u)).dot(v.T))
+    # Check BS eqn.10
+    assert xp.allclose(iCov, Q.dot(Q))
+    #- Calculate the corresponding resolution matrix and diagonal flux errors. (BS Eq 11-13)
+    s = xp.sum(Q, axis=1)
+    R = Q/s[:, xp.newaxis]
+    ivar = s**2
+    # Check BS eqn.14
+    assert xp.allclose(iCov, R.T.dot(xp.diag(ivar).dot(R)))
+    return ivar, R
+    
+
+def xp_decorrelate_blocks(iCov, block_size):
+    """
+    """
+    try:
+        xp = cp.get_array_module(iCov)
+    except NameError:
+        # If the cupy module is unavailble, default to numpy
+        xp = np
+    size = iCov.shape[0]
+    assert size % block_size == 0
+    #- Invert iCov (B&S eq 17)
+    u, v = xp.linalg.eigh((iCov + iCov.T)/2.)
+    assert xp.all(u > 0), 'Found some negative iCov eigenvalues.'
+    # Check that the eigenvectors are orthonormal so that vt.v = 1
+    assert xp.allclose(xp.eye(len(u)), v.T.dot(v))
+    C = (v * (1.0/u)).dot(v.T)
+    #- Calculate C^-1 = QQ (B&S eq 17-19)
+    Q = xp.zeros_like(iCov)
+    #- Proceed one block at a time
+    for i in range(0, size, block_size):
+        s = np.s_[i:i+block_size, i:i+block_size]
+        #- Invert this block
+        bu, bv = xp.linalg.eigh(C[s])
+        assert xp.all(bu > 0), 'Found some negative iCov eigenvalues.'
+        # Check that the eigenvectors are orthonormal so that vt.v = 1
+        assert xp.allclose(xp.eye(len(bu)), bv.T.dot(bv))
+        bQ = (bv * xp.sqrt(1.0/bu)).dot(bv.T)
+        Q[s] = bQ
+    #- Calculate the corresponding resolution matrix and diagonal flux errors. (BS Eq 11-13)
+    s = xp.sum(Q, axis=1)
+    R = Q/s[:, xp.newaxis]
+    ivar = s**2
+    #- Check BS eqn.14
+    assert xp.allclose(Q.dot(Q), R.T.dot(xp.diag(ivar).dot(R)))
+    return ivar, R
+
+def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
+    """
+    """
+    assert decorrelate in ('signal', 'noise')
+    ny, nx, nspec, nwave = A4.shape
+    assert img.shape == (ny, nx)
+    # Flatten arrays
+    pixel_values = img.ravel()
+    pixel_ivar = ivar.ravel()
+    A = A4.reshape(ny*nx, nspec*nwave)
+    # Deconvole fiber traces
+    deconvolved, iCov = xp_deconvolve(pixel_values, pixel_ivar, A)
+    # Calculate the decorrelated errors and resolution matrix.
+    if decorrelate == 'signal':
+        ivar, resolution = xp_decorrelate_blocks(iCov, nwave)
+    elif decorrelate == 'noise':
+        ivar, resolution = xp_decorrelate(iCov)
+    else:
+        raise ValueError(f'{decorrelate} is not a valid value for decorrelate')
+    # Convolve the reduced flux (BS eq 16)
+    flux = resolution.dot(deconvolved).reshape(nspec, nwave)
+    ivar = ivar.reshape(nspec, nwave)
+    return flux, ivar, resolution

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -187,10 +187,18 @@ def multispot(pGHx, pGHy, ghc):
     return spots
 
 def get_spots(specmin, nspec, wavelengths, psfdata):
-    '''
-    TODO: Document
+    '''Calculate PSF spots for the specified spectra and wavelengths
 
-    Returns spots, corners
+    Args:
+        specmin: first spectrum to include
+        nspec: number of spectra to evaluate spots for
+        wavelengths: 1D array of wavelengths
+        psfdata: PSF data from io.read_psf() of Gauss Hermite PSF file
+
+    Returns:
+        spots: 4D array[ispec, iwave, ny, nx] of PSF spots
+        corners: (xc,yc) where each is 2D array[ispec,iwave] lower left corner of spot
+
     '''
     nwave = len(wavelengths)
     p = evalcoeffs(psfdata, wavelengths, specmin, nspec)

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -359,12 +359,12 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
 
     if (0 <= ymin) & (ymin+ny < image.shape[0]):
         xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
-        fx, varfx, R = ex2d_patch(image[xyslice], imageivar[xyslice], A4)
+        fx, ivarfx, R = ex2d_patch(image[xyslice], imageivar[xyslice], A4)
 
         #- Select the non-padded spectra x wavelength core region
         specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
         specflux = fx[specslice]
-        specivar = 1/varfx[specslice]
+        specivar = ivarfx[specslice]
 
         #- TODO: check indexing
         i0 = ispec-specmin
@@ -498,13 +498,10 @@ def ex2d_patch(noisyimg, imgweights, A4, decorrelate='signal'):
     #- Resolution matrix (B&S eq 12)
     R = np.outer(1.0/norm_vector, np.ones(norm_vector.size)) * Q
 
-    #- Decorrelated covariance matrix (B&S eq 13-15)
-    Cx = R.dot(Cov.dot(R.T))
-    
     #- Decorrelated flux (B&S eq 16)
     fx = R.dot(f.ravel()).reshape(f.shape)
     
-    #- Variance on f (B&S eq 13)
-    varfx = np.diagonal(Cx).reshape(fx.shape)
+    #- Inverse variance on f (B&S eq 13)
+    ivarfx = (norm_vector**2).reshape(fx.shape)
     
-    return fx, varfx, R
+    return fx, ivarfx, R

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -14,7 +14,7 @@ from numba import cuda
 from ..io import native_endian
 
 @cuda.jit
-def hermevander(x, deg, output_matrix):
+def _hermevander(x, deg, output_matrix):
     i = cuda.blockIdx.x
     _, j = cuda.grid(2)
     _, stride = cuda.gridsize(2)
@@ -25,7 +25,7 @@ def hermevander(x, deg, output_matrix):
             for k in range(2, deg + 1):
                 output_matrix[i][j][k] = output_matrix[i][j][k-1]*x[i][j] - output_matrix[i][j][k-2]*(k-1)
 
-def hermevander_wrapper(x, deg):
+def hermevander(x, deg):
     """Temprorary wrapper that allocates memory and calls hermevander_gpu
     """
     if x.ndim == 1:
@@ -33,11 +33,11 @@ def hermevander_wrapper(x, deg):
     output = cp.ndarray(x.shape + (deg+1,))
     blocksize = 256
     numblocks = (x.shape[0], (x.shape[1] + blocksize - 1) // blocksize)
-    hermevander[numblocks, blocksize](x, deg, output)
+    _hermevander[numblocks, blocksize](x, deg, output)
     return cp.squeeze(output)
 
 @cuda.jit
-def legvander(x, deg, output_matrix):
+def _legvander(x, deg, output_matrix):
     i = cuda.grid(1)
     stride = cuda.gridsize(1)
     for i in range(i, x.shape[0], stride):
@@ -46,7 +46,7 @@ def legvander(x, deg, output_matrix):
         for j in range(2, deg + 1):
             output_matrix[i][j] = (output_matrix[i][j-1]*x[i]*(2*j - 1) - output_matrix[i][j-2]*(j - 1)) / j
 
-def legvander_wrapper(x, deg):
+def legvander(x, deg):
     """Temporary wrapper that allocates memory and defines grid before calling legvander.
     Probably won't be needed once cupy has the correpsponding legvander function.
 
@@ -56,13 +56,20 @@ def legvander_wrapper(x, deg):
     output = cp.ndarray((len(x), deg + 1))
     blocksize = 256
     numblocks = (len(x) + blocksize - 1) // blocksize
-    legvander[numblocks, blocksize](x, deg, output)
+    _legvander[numblocks, blocksize](x, deg, output)
     return output
 
-def evalcoeffs(wavelengths, psfdata):
+def evalcoeffs(psfdata, wavelengths, specmin=0, nspec=None):
     '''
-    wavelengths: 1D array of wavelengths to evaluate all coefficients for all wavelengths of all spectra
-    psfdata: Table of parameter data ready from a GaussHermite format PSF file
+    evaluate PSF coefficients parameterized as Legendre polynomials
+
+    Args:
+        psfdata: PSF data from io.read_psf() of Gauss Hermite PSF file
+        wavelengths: 1D array of wavelengths
+
+    Options:
+        specmin: first spectrum to include
+        nspec: number of spectra to include (default: all)
 
     Returns a dictionary params[paramname] = value[nspec, nwave]
 
@@ -70,37 +77,56 @@ def evalcoeffs(wavelengths, psfdata):
 
         params['GH'] = value[i,j,nspec,nwave]
 
-    The dictionary also contains scalars with the recommended spot size HSIZEX, HSIZEY
-    and Gauss-Hermite degrees GHDEGX, GHDEGY (which is also derivable from the dimensions
-    of params['GH'])
+    The dictionary also contains scalars with the recommended spot size
+    2*(HSIZEX, HSIZEY)+1 and Gauss-Hermite degrees GHDEGX, GHDEGY
+    (which is also derivable from the dimensions of params['GH'])
     '''
-    # Initialization
-    wavemin, wavemax = psfdata['WAVEMIN'][0], psfdata['WAVEMAX'][0]
-    wx = (wavelengths - wavemin) * (2.0 / (wavemax - wavemin)) - 1.0
+    if nspec is None:
+        nspec = psfdata['PSF']['COEFF'].shape[1]
 
-    L = legvander_wrapper(wx, psfdata.meta['LEGDEG'])
-    p = dict(WAVE=wavelengths) # p doesn't live on the gpu, but it's last-level values do
-    nparam, nspec, ndeg = psfdata['COEFF'].shape
+    p = dict(WAVE=wavelengths)
+
+    #- Evaluate X and Y which have different dimensionality from the
+    #- PSF coefficients (and might have different WAVEMIN, WAVEMAX)
+    meta = psfdata['XTRACE'].meta
+    wavemin, wavemax = meta['WAVEMIN'], meta['WAVEMAX']
+    ww = (wavelengths - wavemin) * (2.0 / (wavemax - wavemin)) - 1.0
+    # TODO: Implement cuda legval
+    p['X'] = cp.asarray(numpy.polynomial.legendre.legval(ww, psfdata['XTRACE']['X'][specmin:specmin+nspec].T))
+
+    meta = psfdata['YTRACE'].meta
+    wavemin, wavemax = meta['WAVEMIN'], meta['WAVEMAX']
+    ww = (wavelengths - wavemin) * (2.0 / (wavemax - wavemin)) - 1.0
+    # TODO: Implement cuda legval
+    p['Y'] = cp.asarray(numpy.polynomial.legendre.legval(ww, psfdata['YTRACE']['Y'][specmin:specmin+nspec].T))
+
+    #- Evaluate the remaining PSF coefficients with a shared dimensionality
+    #- and WAVEMIN, WAVEMAX
+    meta = psfdata['PSF'].meta
+    wavemin, wavemax = meta['WAVEMIN'], meta['WAVEMAX']
+    ww = (wavelengths - wavemin) * (2.0 / (wavemax - wavemin)) - 1.0
+    L = legvander(ww, meta['LEGDEG'])
+
+    nparam = psfdata['PSF']['COEFF'].shape[0]
+    ndeg = psfdata['PSF']['COEFF'].shape[2]
+
     nwave = L.shape[0]
-
-    # Init zeros
-    p['GH'] = cp.zeros((psfdata.meta['GHDEGX']+1, psfdata.meta['GHDEGY']+1, nspec, nwave))
-    # Init gpu coeff
-    coeff_gpu = cp.array(native_endian(psfdata['COEFF']))
-
-    k = 0
-    for name, coeff in zip(psfdata['PARAM'], psfdata['COEFF']):
+    nghx = meta['GHDEGX']+1
+    nghy = meta['GHDEGY']+1
+    p['GH'] = cp.zeros((nghx, nghy, nspec, nwave))
+    coeff_gpu = cp.array(native_endian(psfdata['PSF']['COEFF']))
+    for name, coeff in zip(psfdata['PSF']['PARAM'], coeff_gpu):
         name = name.strip()
+        coeff = coeff[specmin:specmin+nspec]
         if name.startswith('GH-'):
             i, j = map(int, name.split('-')[1:3])
-            p['GH'][i,j] = L.dot(coeff_gpu[k].T).T
+            p['GH'][i,j] = L.dot(coeff.T).T
         else:
-            p[name] = L.dot(coeff_gpu[k].T).T
-        k += 1
+            p[name] = L.dot(coeff.T).T
 
     #- Include some additional keywords that we'll need
     for key in ['HSIZEX', 'HSIZEY', 'GHDEGX', 'GHDEGY']:
-        p[key] = psfdata.meta[key]
+        p[key] = meta[key]
 
     return p
 

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -13,6 +13,8 @@ from numba import cuda
 
 from ..io import native_endian
 
+import numpy.polynomial.legendre
+
 @cuda.jit
 def _hermevander(x, deg, output_matrix):
     i = cuda.blockIdx.x

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -4,6 +4,8 @@ the pieces have not yet been put together into a working GPU extraction
 in this branch.
 """
 
+import math
+
 import numpy as np
 import cupy as cp
 import cupyx.scipy.special
@@ -235,6 +237,7 @@ def projection_matrix(ispec, nspec, iwave, nwave, spots, corners):
     xmin, xmax, ymin, ymax = get_xyrange(ispec, nspec, iwave, nwave, spots, corners)
     A = cp.zeros((ymax-ymin,xmax-xmin,nspec,nwave), dtype=np.float64)
 
+    threads_per_block = (16, 16)
     blocks_per_grid_x = math.ceil(A.shape[0] / threads_per_block[0])
     blocks_per_grid_y = math.ceil(A.shape[1] / threads_per_block[1])
     blocks_per_grid = (blocks_per_grid_x, blocks_per_grid_y)
@@ -242,4 +245,4 @@ def projection_matrix(ispec, nspec, iwave, nwave, spots, corners):
     _cuda_projection_matrix[blocks_per_grid, threads_per_block](
         A, xc, yc, xmin, ymin, ispec, iwave, nspec, nwave, spots)
 
-    return A, xyrange
+    return A, (xmin, xmax, ymin, ymax)

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -232,6 +232,19 @@ def _multispot(pGHx, pGHy, ghc, mspots):
                         mspots[iwave, iy, ix] += c * py[iy] * px[ix]
 
 def get_spots(specmin, nspec, wavelengths, psfdata):
+    '''Calculate PSF spots for the specified spectra and wavelengths
+
+    Args:
+        specmin: first spectrum to include
+        nspec: number of spectra to evaluate spots for
+        wavelengths: 1D array of wavelengths
+        psfdata: PSF data from io.read_psf() of Gauss Hermite PSF file
+
+    Returns:
+        spots: 4D array[ispec, iwave, ny, nx] of PSF spots
+        corners: (xc,yc) where each is 2D array[ispec,iwave] lower left corner of spot
+
+    '''
     nwave = len(wavelengths)
     p = evalcoeffs(psfdata, wavelengths, specmin, nspec)
     nx = 2*p['HSIZEX']+1

--- a/py/gpu_specter/test/test_ex2d_patch.py
+++ b/py/gpu_specter/test/test_ex2d_patch.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from gpu_specter.io import read_psf
 from gpu_specter.extract.cpu import projection_matrix, get_spots, ex2d_patch
+from gpu_specter.extract.both import xp_ex2d_patch
 
 try:
     import specter.psf
@@ -12,6 +13,12 @@ try:
     specter_available = True
 except ImportError:
     specter_available = False
+
+try:
+    import cupy as cp
+    cupy_available = True
+except ImportError:
+    cupy_available = False
 
 class TestEx2dPatch(unittest.TestCase):
 
@@ -41,6 +48,19 @@ class TestEx2dPatch(unittest.TestCase):
 
         cls.phot = phot
 
+        xmin, xmax, ymin, ymax = cls.xyrange
+        ny = ymax - ymin
+        nx = xmax - xmin
+
+        A2 = cls.A4.reshape(ny*nx, nspec*nwave)
+        cls.img = A2.dot(cls.phot.ravel()).reshape(ny, nx)
+
+        cls.readnoise = 3.0
+        cls.noisyimg = np.random.normal(loc=0.0, scale=cls.readnoise, size=(ny, nx))
+        cls.noisyimg += np.random.poisson(cls.img)
+        #- for test, cheat by using noiseless img instead of noisyimg to estimate variance
+        cls.imgivar = 1.0/(cls.img + cls.readnoise**2)
+
     @classmethod
     def tearDownClass(cls):
         pass
@@ -63,6 +83,57 @@ class TestEx2dPatch(unittest.TestCase):
         self.assertEqual(varflux.shape, (nspec, nwave))
         self.assertEqual(R.shape, (nspec*nwave, nspec*nwave))
 
+    def test_compare_xp_cpu(self):
+        # Compare the "signal" decorrelation method
+        flux0, ivar0, R0 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='signal')
+        flux1, ivar1, R1 = xp_ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='signal')
+
+        self.assertTrue(np.allclose(flux0, flux1))
+        self.assertTrue(np.allclose(ivar0, ivar1))
+        self.assertTrue(np.allclose(R0, R1))
+        self.assertTrue(np.allclose(np.abs(flux0 - flux1)/np.sqrt(1./ivar0 + 1./ivar1), np.zeros_like(flux0)))
+
+        # Compare the "noise" decorrelation method
+        flux0, ivar0, R0 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='noise')
+        flux1, ivar1, R1 = xp_ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='noise')
+
+        self.assertTrue(np.allclose(flux0, flux1))
+        self.assertTrue(np.allclose(ivar0, ivar1))
+        self.assertTrue(np.allclose(R0, R1))
+        self.assertTrue(np.allclose(np.abs(flux0 - flux1)/np.sqrt(1./ivar0 + 1./ivar1), np.zeros_like(flux0)))
+
+    @unittest.skipIf(not cupy_available, 'cupy not available')
+    def test_compare_xp_gpu(self):
+        noisyimg_gpu = cp.asaarray(self.noisyimg)
+        imgivar_gpu = cp.asaarray(self.imgivar)
+        A4_gpu = cp.asaarray(self.A4)
+
+        # Compare the "signal" decorrelation method
+        flux0, ivar0, R0 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='signal')
+        flux1_gpu, ivar1_gpu, R1_gpu = xp_ex2d_patch(noisyimg_gpu, imgivar_gpu, A4_gpu, decorrelate='signal')
+
+        flux1 = cp.asnumpy(flux1_gpu)
+        ivar1 = cp.asnumpy(ivar1_gpu)
+        R1 = cp.asnumpy(R1_gpu)
+
+        self.assertTrue(np.allclose(flux0, flux1))
+        self.assertTrue(np.allclose(ivar0, ivar1))
+        self.assertTrue(np.allclose(R0, R1))
+        self.assertTrue(np.allclose(np.abs(flux0 - flux1)/np.sqrt(1./ivar0 + 1./ivar1), np.zeros_like(flux0)))
+
+        # Compare the "noise" decorrelation method
+        flux0, ivar0, R0 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='noise')
+        flux1_gpu, ivar1_gpu, R1_gpu = xp_ex2d_patch(noisyimg_gpu, imgivar_gpu, A4_gpu, decorrelate='noise')
+
+        flux1 = cp.asnumpy(flux1_gpu)
+        ivar1 = cp.asnumpy(ivar1_gpu)
+        R1 = cp.asnumpy(R1_gpu)
+
+        self.assertTrue(np.allclose(flux0, flux1))
+        self.assertTrue(np.allclose(ivar0, ivar1))
+        self.assertTrue(np.allclose(R0, R1))
+        self.assertTrue(np.allclose(np.abs(flux0 - flux1)/np.sqrt(1./ivar0 + 1./ivar1), np.zeros_like(flux0)))
+
     @unittest.skipIf(not specter_available, 'specter not available')
     def test_compare_specter(self):
         ny, nx, nspec, nwave = self.A4.shape
@@ -70,32 +141,32 @@ class TestEx2dPatch(unittest.TestCase):
         psf = specter.psf.load_psf(self.psffile)
         img = psf.project(self.wavelengths, self.phot, xyrange=self.xyrange)
 
-        readnoise = 3.0
-        noisyimg = np.random.normal(loc=0.0, scale=readnoise, size=img.shape)
-        noisyimg += np.random.poisson(img)
-        #- for test, cheat by using noiseless img instead of noisyimg to estimate variance
-        imgivar = 1.0/(img + readnoise**2)   
+        # self.assertTrue(np.allclose(self.img, img))
 
-        #- Compare default mode
-        flux0, ivar0, R0 = specter.extract.ex2d_patch(
-            noisyimg, imgivar, psf, 0, nspec, self.wavelengths, xyrange=self.xyrange)
-        #- TODO: test using the same projection matrix?
-        # A = psf.projection_matrix((0, nspec), wavelengths, xyrange).toarray()
-        # A4 = A.reshape(A4.shape)
-        flux1, varflux1, R1 = ex2d_patch(noisyimg, imgivar, self.A4)
+        #- Compare the "signal" decorrelation method
+        flux0, ivar0, R0 = specter.extract.ex2d_patch(self.noisyimg, self.imgivar, psf, 0, nspec,
+            self.wavelengths, xyrange=self.xyrange, ndecorr=False)
+        flux1, ivar1, R1 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='signal')
+
+        #- Note that specter is using it's version of the projection matrix
+        # A = psf.projection_matrix((0, nspec), self.wavelengths, self.xyrange).toarray()
+        # A4 = A.reshape(self.A4.shape)
+        # flux1, ivar1, R1 = ex2d_patch(self.noisyimg, self.imgivar, A4, decorrelate='signal')
 
         self.assertTrue(np.allclose(flux0, flux1))
-        self.assertTrue(np.allclose(ivar0, 1.0/varflux1))
+        self.assertTrue(np.allclose(ivar0, ivar1))
         self.assertTrue(np.allclose(R0, R1))
+        #self.assertTrue(np.allclose(np.abs(flux0 - flux1)/np.sqrt(1./ivar0 + 1./ivar1), np.zeros_like(flux0)))
 
-        #- Compare decorrelation across neighboring fibers mode
-        flux2, ivar2, R2 = specter.extract.ex2d_patch(
-            noisyimg, imgivar, psf, 0, nspec, self.wavelengths, xyrange=self.xyrange, ndecorr=True)
-        flux3, varflux3, R3 = ex2d_patch(noisyimg, imgivar, self.A4, decorrelate='noise')
+        # Compare the "noise" decorrelation method
+        flux0, ivar0, R0 = specter.extract.ex2d_patch(self.noisyimg, self.imgivar, psf, 0, nspec,
+            self.wavelengths, xyrange=self.xyrange, ndecorr=True)
+        flux1, ivar1, R1 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='noise')
 
-        self.assertTrue(np.allclose(flux2, flux3))
-        self.assertTrue(np.allclose(ivar2, 1.0/varflux3))
-        self.assertTrue(np.allclose(R2, R3))
+        self.assertTrue(np.allclose(flux0, flux1))
+        self.assertTrue(np.allclose(ivar0, ivar1))
+        self.assertTrue(np.allclose(R0, R1))
+        #self.assertTrue(np.allclose(np.abs(flux0 - flux1)/np.sqrt(1./ivar0 + 1./ivar1), np.zeros_like(flux0)))
 
 
 if __name__ == '__main__':

--- a/py/gpu_specter/test/test_ex2d_patch.py
+++ b/py/gpu_specter/test/test_ex2d_patch.py
@@ -16,7 +16,7 @@ except ImportError:
 
 try:
     import cupy as cp
-    cupy_available = True
+    cupy_available = cp.is_available()
 except ImportError:
     cupy_available = False
 

--- a/py/gpu_specter/test/test_ex2d_patch.py
+++ b/py/gpu_specter/test/test_ex2d_patch.py
@@ -104,9 +104,9 @@ class TestEx2dPatch(unittest.TestCase):
 
     @unittest.skipIf(not cupy_available, 'cupy not available')
     def test_compare_xp_gpu(self):
-        noisyimg_gpu = cp.asaarray(self.noisyimg)
-        imgivar_gpu = cp.asaarray(self.imgivar)
-        A4_gpu = cp.asaarray(self.A4)
+        noisyimg_gpu = cp.asarray(self.noisyimg)
+        imgivar_gpu = cp.asarray(self.imgivar)
+        A4_gpu = cp.asarray(self.A4)
 
         # Compare the "signal" decorrelation method
         flux0, ivar0, R0 = ex2d_patch(self.noisyimg, self.imgivar, self.A4, decorrelate='signal')

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -14,7 +14,7 @@ except ImportError:
 
 try:
     import cupy as cp
-    from numbda import cuda
+    from numba import cuda
     from gpu_specter.extract.gpu import projection_matrix as gpu_projection_matrix
     gpu_available = True
 except ImportError:

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -16,7 +16,7 @@ try:
     import cupy as cp
     from numba import cuda
     from gpu_specter.extract.gpu import projection_matrix as gpu_projection_matrix
-    gpu_available = True
+    gpu_available = cp.is_available()
 except ImportError:
     gpu_available = False
 

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -12,6 +12,14 @@ try:
 except ImportError:
     specter_available = False
 
+try:
+    import cupy as cp
+    from numbda import cuda
+    from gpu_specter.extract.gpu import projection_matrix as gpu_projection_matrix
+    gpu_available = True
+except ImportError:
+    gpu_available = False
+
 class TestProjectionMatrix(unittest.TestCase):
 
     @classmethod
@@ -45,6 +53,34 @@ class TestProjectionMatrix(unittest.TestCase):
             ispec=10, nspec=5, iwave=20, nwave=25, spots=spots, corners=corners)
         self.assertEqual(A4.shape[2:4], (5,25))
         self.assertEqual(A4.shape[0:2], (ymax-ymin, xmax-xmin))
+
+    @unittest.skipIf(not gpu_available, 'gpu not available')
+    def test_compare_gpu(self):
+        wavelengths = np.arange(6000.0, 6050.0, 1.0)
+        spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
+
+        spots_gpu = cp.asarray(spots)
+        corners_gpu = [cp.asarray(c) for c in corners]
+
+        #- Compare projection matrix for a few combos of spectra & waves
+        for ispec, nspec, iwave, nwave in (
+            (0, 5, 0, 25),
+            (10, 5, 20, 25),
+            (7, 3, 10, 12),
+            ):
+
+            #- cpu projection matrix
+            A4, xyrange = projection_matrix(
+                ispec=ispec, nspec=nspec, iwave=iwave, nwave=nwave, spots=spots, corners=corners)
+
+            #- gpu projection matrix
+            A4_gpu, xyrange_gpu = gpu_projection_matrix(
+                ispec=ispec, nspec=nspec, iwave=iwave, nwave=nwave, spots=spots_gpu, corners=corners_gpu)
+
+            self.assertEqual(xyrange, xyrange_gpu)
+            self.assertEqual(A4.shape, A4_gpu.shape)
+            self.assertTrue(cp.allclose(A4, A4_gpu))
+
 
     @unittest.skipIf(not specter_available, 'specter not available')
     def test_compare_specter(self):

--- a/py/gpu_specter/test/test_psfcoeff.py
+++ b/py/gpu_specter/test/test_psfcoeff.py
@@ -97,7 +97,7 @@ class TestPSFCoeff(unittest.TestCase):
         for i in range(psfparams['GH'].shape[0]):
             for j in range(psfparams['GH'].shape[1]):
                 # print(f'Comparing GH-{i}-{j}')
-                ok = np.allclose(psfparams['GH'][i,j], psfparams_gpu[key])
+                ok = np.allclose(psfparams['GH'][i,j], psfparams_gpu['GH'][i,j])
                 self.assertTrue(ok, f'GH-{i}-{j}')
 
 

--- a/py/gpu_specter/test/test_psfcoeff.py
+++ b/py/gpu_specter/test/test_psfcoeff.py
@@ -16,7 +16,7 @@ try:
     import cupy as cp
     from numba import cuda
     from gpu_specter.extract.gpu import evalcoeffs as gpu_evalcoeffs
-    gpu_available = True
+    gpu_available = cp.is_available()
 except ImportError:
     gpu_available = False
 

--- a/py/gpu_specter/test/test_spots.py
+++ b/py/gpu_specter/test/test_spots.py
@@ -17,7 +17,7 @@ try:
     import cupy as cp
     from numba import cuda
     from gpu_specter.extract.gpu import get_spots as gpu_get_spots
-    gpu_available = True
+    gpu_available = cp.is_available()
 except ImportError:
     gpu_available = False
 

--- a/py/gpu_specter/test/test_spots.py
+++ b/py/gpu_specter/test/test_spots.py
@@ -95,8 +95,8 @@ class TestPSFSpots(unittest.TestCase):
             xc_gpu, yc_gpu = corners_gpu
 
             self.assertTrue(cp.allclose(xc, xc_gpu))
-            self.assertTrue(cp.allclose(yx, yc_gpu))
-            self.asserEqual(spots.shape, spots_gpu.shape)
+            self.assertTrue(cp.allclose(yc, yc_gpu))
+            self.assertEqual(spots.shape, spots_gpu.shape)
             self.assertTrue(cp.allclose(spots, spots_gpu))
 
 

--- a/py/gpu_specter/test/test_spots.py
+++ b/py/gpu_specter/test/test_spots.py
@@ -13,6 +13,15 @@ try:
 except ImportError:
     specter_available = False
 
+try:
+    import cupy as cp
+    from numba import cuda
+    from gpu_specter.extract.gpu import get_spots as gpu_get_spots
+    gpu_available = True
+except ImportError:
+    gpu_available = False
+
+
 class TestPSFSpots(unittest.TestCase):
 
     @classmethod
@@ -75,6 +84,21 @@ class TestPSFSpots(unittest.TestCase):
                 msg = f'ispec={ispec}, iwave={iwave}'
                 self.assertTrue((-0.7 <= dx) and (dx < 0.7), msg + f' dx={dx}')
                 self.assertTrue((-0.7 <= dy) and (dy < 0.7), msg + f' dy={dy}')
+
+    @unittest.skipIf(not gpu_available, 'gpu not available')
+    def test_compare_gpu(self):
+        for ispec in np.linspace(0, 499, 20).astype(int):
+            spots, corners = get_spots(ispec, 1, self.wavelengths, self.psfdata)
+            xc, yc = corners
+
+            spots_gpu, corners_gpu = gpu_get_spots(ispec, 1, self.wavelengths, self.psfdata)
+            xc_gpu, yc_gpu = corners_gpu
+
+            self.assertTrue(cp.allclose(xc, xc_gpu))
+            self.assertTrue(cp.allclose(yx, yc_gpu))
+            self.asserEqual(spots.shape, spots_gpu.shape)
+            self.assertTrue(cp.allclose(spots, spots_gpu))
+
 
     @unittest.skipIf(not specter_available, 'specter not available')
     def test_compare_specter(self):

--- a/py/gpu_specter/util.py
+++ b/py/gpu_specter/util.py
@@ -6,6 +6,34 @@ import time, datetime
 
 import os, logging
 
+import numpy as np
+
+try:
+    import cupy as cp
+except ImportError:
+    pass
+
+def get_array_module(x):
+    """Returns the array module for arguments.
+
+    This function is used to implement CPU/GPU generic code. If the argument
+    is a :class:`cupy.ndarray` object, the :mod:`cupy` module is returned.
+
+    For more details see: https://docs-cupy.chainer.org/en/stable/reference/generated/cupy.get_array_module.html
+
+    Args:
+        args: array to determine whether NumPy or CuPy should be used.
+
+    Returns:
+        module: :mod:`cupy` or :mod:`numpy` is returned based on the types of
+        the arguments.
+    """
+    try:
+        return cp.get_array_module(x)
+    except NameError:
+        # If the cupy module is unavailble, default to numpy
+        return np
+
 #- subset of desiutil.log.get_logger, to avoid desiutil dependency
 _loggers = dict()
 def get_logger(level=None):


### PR DESCRIPTION
This PR adds unit tests that compare the cpu and gpu versions of the functions implemented in `gpu_specter.extract`. All of the gpu functions in `gpu_specter.extract.gpu` have been updated to match the interface and functionality of their versions in `gpu_specter.extract.cpu`. 

There are just a few functions left that do not have a gpu version, notably, `gpu_specter.extract.cpu.ex2d_padded` and `numpy.polynomial.legendre.legval`.

The new `gpu_specter.extract.both.xp_ex2d_patch` is a version of `gpu_specter.extract.cpu.ex2d_patch` that is compatible with inputs from either `numpy.ndarray` or `cupy.ndarray`. 

The figure below compares the runtime for a single patch using the numba optimized `gpu_specter.extract.cpu.ex2d_patch`, the new `xp_ex2d_patch` with `cupy.ndarray` inputs, and the new`xp_ex2d_patch` with `numpy.ndarray` inputs. The projection matrix shape for this patch corresponds to `A4.shape = (ny, nx, nspec, nwave) = (102, 46, 5, 50)`. The benchmark was performed in a jupyter notebook on a cori shared gpu node.

![image](https://user-images.githubusercontent.com/1648834/83278466-80fe6000-a188-11ea-97c9-7d4d07b57c7a.png)


