### PR TITLE
Enable gpu spex

### DIFF
--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -197,12 +197,14 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                              bundlesize=bundlesize)
         results.append( (patch, result) )
 
+    timer.split('extracted patches')
+
     if comm is not None:
         rankresults = comm.gather(results, root=0)
     else:
         rankresults = [results,]
 
-    timer.split('extracted patches')
+    timer.split('gathered patches')
 
     bundle = None
     if rank == 0:

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -215,7 +215,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
     bundle = None
     if rank == 0:
         if gpu:
-            cp.cuda.nvtx.RangePush('assemble patchs on device')
+            cp.cuda.nvtx.RangePush('assemble patches on device')
         bundle = assemble_bundle_patches(rankresults)
         if gpu:
             cp.cuda.nvtx.RangePop()
@@ -224,7 +224,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
 
     if gpu:
         cp.cuda.nvtx.RangePush('copy bundle results to host')
-        bundle = (cp.asnumpy(x) for x in bundle)
+        bundle = list(cp.asnumpy(x) for x in bundle)
         cp.cuda.nvtx.RangePop()
         cp.cuda.nvtx.RangePop()
 

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -195,12 +195,18 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
         #- Always extract the same patch size (more efficient for GPU
         #- memory transfer) then decide post-facto whether to keep it all
 
+        if gpu:
+            cp.cuda.nvtx.RangePush('ex2d_padded')
+
         result = ex2d_padded(image, imageivar,
                              patch.ispec-bspecmin, patch.nspectra_per_patch,
                              patch.iwave, patch.nwavestep,
                              spots, corners,
                              wavepad=patch.wavepad,
                              bundlesize=bundlesize)
+        if gpu:
+            cp.cuda.nvtx.RangePop()
+
         results.append( (patch, result) )
 
     timer.split('extracted patches')

--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -9,6 +9,15 @@ from ..util import Timer
 from ..util import get_array_module
 from .cpu import get_spec_padding
 
+
+def safe_range_push(xp, name):
+    if xp.__name__ == 'cupy':
+        xp.cuda.nvtx.RangePush(name)
+
+def safe_range_pop(xp):
+    if xp.__name__ == 'cupy':
+        xp.cuda.nvtx.RangePop()
+
 def xp_deconvolve(pixel_values, pixel_ivar, A):
     """Calculate the weighted linear least-squares flux solution for an observed trace.
 
@@ -26,9 +35,11 @@ def xp_deconvolve(pixel_values, pixel_ivar, A):
     assert xp == get_array_module(pixel_values)
     assert xp == get_array_module(pixel_ivar)
     #- Set up the equation to solve (B&S eq 4)
+    safe_range_push(xp, 'BS Eq 4 Setup')
     ATNinv = A.T.dot(xp.diag(pixel_ivar))
     iCov = ATNinv.dot(A)
     iCov += 1e-12*xp.eye(iCov.shape[0])
+    safe_range_pop(xp)
     #- Solve the linear least-squares problem.
     #- Force rcond to be the same when using cupy/numpy 
     #- See: https://github.com/numpy/numpy/blob/v1.18.4/numpy/linalg/linalg.py#L2247
@@ -36,7 +47,9 @@ def xp_deconvolve(pixel_values, pixel_ivar, A):
     # deconvolved, res, rank, sing = xp.linalg.lstsq(iCov, ATNinv.dot(pixel_values), rcond=rcond)
     # if rank < len(deconvolved):
     #     print('WARNING: deconvolved inverse-covariance is not positive definite.')
+    safe_range_push(xp, 'BS Eq 4 Solve')
     deconvolved = xp.linalg.solve(iCov, ATNinv.dot(pixel_values))
+    safe_range_pop(xp)
     return deconvolved, iCov
 
 def xp_decorrelate(iCov):
@@ -66,7 +79,7 @@ def xp_decorrelate(iCov):
     # Check BS eqn.14
     assert xp.allclose(iCov, R.T.dot(xp.diag(ivar).dot(R)))
     return ivar, R
-    
+
 
 def xp_decorrelate_blocks(iCov, block_size):
     """Calculate the decorrelated errors and resolution matrix via BS Eq 19
@@ -83,12 +96,17 @@ def xp_decorrelate_blocks(iCov, block_size):
     size = iCov.shape[0]
     assert size % block_size == 0
     #- Invert iCov (B&S eq 17)
+    safe_range_push(xp, 'iCov eigh decompose')
     u, v = xp.linalg.eigh((iCov + iCov.T)/2.)
+    safe_range_pop(xp)
     assert xp.all(u > 0), 'Found some negative iCov eigenvalues.'
     # Check that the eigenvectors are orthonormal so that vt.v = 1
     assert xp.allclose(xp.eye(len(u)), v.T.dot(v))
+    safe_range_push(xp, 'compose C')
     C = (v * (1.0/u)).dot(v.T)
+    safe_range_pop(xp)
     #- Calculate C^-1 = QQ (B&S eq 17-19)
+    safe_range_push(xp, 'C^-1 = QQ by block')
     Q = xp.zeros_like(iCov)
     #- Proceed one block at a time
     for i in range(0, size, block_size):
@@ -100,10 +118,13 @@ def xp_decorrelate_blocks(iCov, block_size):
         assert xp.allclose(xp.eye(len(bu)), bv.T.dot(bv))
         bQ = (bv * xp.sqrt(1.0/bu)).dot(bv.T)
         Q[s] = bQ
+    safe_range_pop(xp)
     #- Calculate the corresponding resolution matrix and diagonal flux errors. (BS Eq 11-13)
+    safe_range_push(xp, 'resolution and ivar')
     s = xp.sum(Q, axis=1)
     R = Q/s[:, xp.newaxis]
     ivar = s**2
+    safe_range_pop(xp)
     #- Check BS eqn.14
     assert xp.allclose(Q.dot(Q), R.T.dot(xp.diag(ivar).dot(R)))
     return ivar, R
@@ -122,6 +143,8 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
         R (nspec*nwave, nspec*nwave): dense resolution matrix
     """
     # timer = Timer()
+    xp = get_array_module(A4)
+    safe_range_push(xp, 'patch init')
     assert decorrelate in ('signal', 'noise')
     ny, nx, nspec, nwave = A4.shape
     assert img.shape == (ny, nx)
@@ -129,21 +152,28 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
     pixel_values = img.ravel()
     pixel_ivar = ivar.ravel()
     A = A4.reshape(ny*nx, nspec*nwave)
+    safe_range_pop(xp)
     # timer.split('init')
     # Deconvole fiber traces
+    safe_range_push(xp, 'deconvolve')
     deconvolved, iCov = xp_deconvolve(pixel_values, pixel_ivar, A)
+    safe_range_pop(xp)
     # timer.split('deconvolve')
     # Calculate the decorrelated errors and resolution matrix.
+    safe_range_push(xp, 'decorrelate')
     if decorrelate == 'signal':
         fluxivar, resolution = xp_decorrelate_blocks(iCov, nwave)
     elif decorrelate == 'noise':
         fluxivar, resolution = xp_decorrelate(iCov)
     else:
         raise ValueError(f'{decorrelate} is not a valid value for decorrelate')
+    safe_range_pop(xp)
     # timer.split('decorrelate')
     # Convolve the reduced flux (BS eq 16)
+    safe_range_push(xp, 'reconvolve')
     flux = resolution.dot(deconvolved).reshape(nspec, nwave)
     fluxivar = fluxivar.reshape(nspec, nwave)
+    safe_range_pop(xp)
     # timer.split('reconvolve')
     # timer.print_splits()
     return flux, fluxivar, resolution

--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -32,10 +32,11 @@ def xp_deconvolve(pixel_values, pixel_ivar, A):
     #- Solve the linear least-squares problem.
     #- Force rcond to be the same when using cupy/numpy 
     #- See: https://github.com/numpy/numpy/blob/v1.18.4/numpy/linalg/linalg.py#L2247
-    rcond = np.core.finfo(iCov.dtype).eps * max(iCov.shape)
-    deconvolved, res, rank, sing = xp.linalg.lstsq(iCov, ATNinv.dot(pixel_values), rcond=rcond)
-    if rank < len(deconvolved):
-        print('WARNING: deconvolved inverse-covariance is not positive definite.')
+    # rcond = np.core.finfo(iCov.dtype).eps * max(iCov.shape)
+    # deconvolved, res, rank, sing = xp.linalg.lstsq(iCov, ATNinv.dot(pixel_values), rcond=rcond)
+    # if rank < len(deconvolved):
+    #     print('WARNING: deconvolved inverse-covariance is not positive definite.')
+    deconvolved = xp.linalg.solve(iCov, ATNinv.dot(pixel_values))
     return deconvolved, iCov
 
 def xp_decorrelate(iCov):

--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -121,7 +121,7 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
         ivar (nspec, nwave): uncorrelated flux inverse variances
         R (nspec*nwave, nspec*nwave): dense resolution matrix
     """
-    timer = Timer()
+    # timer = Timer()
     assert decorrelate in ('signal', 'noise')
     ny, nx, nspec, nwave = A4.shape
     assert img.shape == (ny, nx)
@@ -129,10 +129,10 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
     pixel_values = img.ravel()
     pixel_ivar = ivar.ravel()
     A = A4.reshape(ny*nx, nspec*nwave)
-    timer.split('init')
+    # timer.split('init')
     # Deconvole fiber traces
     deconvolved, iCov = xp_deconvolve(pixel_values, pixel_ivar, A)
-    timer.split('deconvolve')
+    # timer.split('deconvolve')
     # Calculate the decorrelated errors and resolution matrix.
     if decorrelate == 'signal':
         fluxivar, resolution = xp_decorrelate_blocks(iCov, nwave)
@@ -140,10 +140,10 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
         fluxivar, resolution = xp_decorrelate(iCov)
     else:
         raise ValueError(f'{decorrelate} is not a valid value for decorrelate')
-    timer.split('decorrelate')
+    # timer.split('decorrelate')
     # Convolve the reduced flux (BS eq 16)
     flux = resolution.dot(deconvolved).reshape(nspec, nwave)
     fluxivar = fluxivar.reshape(nspec, nwave)
-    timer.split('reconvolve')
-    timer.print_splits()
+    # timer.split('reconvolve')
+    # timer.print_splits()
     return flux, fluxivar, resolution

--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -5,6 +5,7 @@ for both CPU and GPU by leveraging the compatible API of NumPy and CuPy.
 
 import numpy as np
 
+from ..util import Timer
 from ..util import get_array_module
 from .cpu import get_spec_padding
 
@@ -119,6 +120,7 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
         ivar (nspec, nwave): uncorrelated flux inverse variances
         R (nspec*nwave, nspec*nwave): dense resolution matrix
     """
+    timer = Timer()
     assert decorrelate in ('signal', 'noise')
     ny, nx, nspec, nwave = A4.shape
     assert img.shape == (ny, nx)
@@ -126,16 +128,21 @@ def xp_ex2d_patch(img, ivar, A4, decorrelate='signal'):
     pixel_values = img.ravel()
     pixel_ivar = ivar.ravel()
     A = A4.reshape(ny*nx, nspec*nwave)
+    timer.split('init')
     # Deconvole fiber traces
     deconvolved, iCov = xp_deconvolve(pixel_values, pixel_ivar, A)
+    timer.split('deconvolve')
     # Calculate the decorrelated errors and resolution matrix.
     if decorrelate == 'signal':
-        ivar, resolution = xp_decorrelate_blocks(iCov, nwave)
+        fluxivar, resolution = xp_decorrelate_blocks(iCov, nwave)
     elif decorrelate == 'noise':
-        ivar, resolution = xp_decorrelate(iCov)
+        fluxivar, resolution = xp_decorrelate(iCov)
     else:
         raise ValueError(f'{decorrelate} is not a valid value for decorrelate')
+    timer.split('decorrelate')
     # Convolve the reduced flux (BS eq 16)
     flux = resolution.dot(deconvolved).reshape(nspec, nwave)
-    ivar = ivar.reshape(nspec, nwave)
-    return flux, ivar, resolution
+    fluxivar = fluxivar.reshape(nspec, nwave)
+    timer.split('reconvolve')
+    timer.print_splits()
+    return flux, fluxivar, resolution

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -339,11 +339,101 @@ def projection_matrix(ispec, nspec, iwave, nwave, spots, corners):
     A = cp.zeros((ymax-ymin,xmax-xmin,nspec,nwave), dtype=np.float64)
 
     threads_per_block = (16, 16)
-    blocks_per_grid_x = math.ceil(A.shape[0] / threads_per_block[0])
-    blocks_per_grid_y = math.ceil(A.shape[1] / threads_per_block[1])
+    blocks_per_grid_y = math.ceil(A.shape[0] / threads_per_block[0])
+    blocks_per_grid_x = math.ceil(A.shape[1] / threads_per_block[1])
     blocks_per_grid = (blocks_per_grid_x, blocks_per_grid_y)
 
     _cuda_projection_matrix[blocks_per_grid, threads_per_block](
         A, xc, yc, xmin, ymin, ispec, iwave, nspec, nwave, spots)
 
     return A, (xmin, xmax, ymin, ymax)
+
+
+
+from .cpu import get_spec_padding
+from .both import xp_ex2d_patch
+
+def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
+                wavepad, bundlesize=25):
+    """
+    Extracted a patch with border padding, but only return results for patch
+
+    Args:
+        image: full image (not trimmed to a particular xy range)
+        imageivar: image inverse variance (same dimensions as image)
+        ispec: starting spectrum index relative to `spots` indexing
+        nspec: number of spectra to extract (not including padding)
+        iwave: starting wavelength index
+        nwave: number of wavelengths to extract (not including padding)
+        spots: array[nspec, nwave, ny, nx] pre-evaluated PSF spots
+        corners: tuple of arrays xcorners[nspec, nwave], ycorners[nspec, nwave]
+        wavepad: number of extra wave bins to extract (and discard) on each end
+
+    Options:
+        bundlesize: size of fiber bundles; padding not needed on their edges
+    """
+
+    specmin, nspecpad = get_spec_padding(ispec, nspec, bundlesize)
+
+    #- Total number of wavelengths to be extracted, including padding
+    nwavetot = nwave+2*wavepad
+
+    #- Get the projection matrix for the full wavelength range with padding
+    A4, xyrange = projection_matrix(specmin, nspecpad,
+        iwave-wavepad, nwave+2*wavepad, spots, corners)
+
+    xmin, xmax, ypadmin, ypadmax = xyrange
+
+    #- But we only want to use the pixels covered by the original wavelengths
+    #- TODO: this unnecessarily also re-calculates xranges
+    xlo, xhi, ymin, ymax = get_xyrange(specmin, nspecpad, iwave, nwave, spots, corners)
+    ypadlo = ymin - ypadmin
+    ypadhi = ypadmax - ymax
+    A4 = A4[ypadlo:-ypadhi]
+
+    #- Number of image pixels in y and x
+    ny, nx = A4.shape[0:2]
+
+    #- Check dimensions
+    assert A4.shape[2] == nspecpad
+    assert A4.shape[3] == nwave + 2*wavepad
+
+    #- Diagonals of R in a form suited for creating scipy.sparse.dia_matrix
+    ndiag = spots.shape[2]//2
+    Rdiags = cp.zeros( (nspec, 2*ndiag+1, nwave) )
+
+    if (0 <= ymin) & (ymin+ny < image.shape[0]):
+        xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
+        fx, ivarfx, R = xp_ex2d_patch(image[xyslice], imageivar[xyslice], A4)
+
+        #- Select the non-padded spectra x wavelength core region
+        specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
+        specflux = fx[specslice]
+        specivar = ivarfx[specslice]
+
+        #- TODO: check indexing
+        i0 = ispec-specmin
+        for i in np.arange(i0, i0+nspec):
+            #- subregion of R for this spectrum
+            ii = slice(nwavetot*i, nwavetot*(i+1))
+            Rx = R[ii, ii]
+
+            #- subregion of non-padded wavelengths for this spectrum
+            for j in range(wavepad,wavepad+nwave):
+                # Rdiags dimensions [nspec, 2*ndiag+1, nwave]
+                Rdiags[i-i0, :, j-wavepad] = Rx[j-ndiag:j+ndiag+1, j]
+
+    else:
+        #- TODO: this zeros out the entire patch if any of it is off the edge
+        #- of the image; we can do better than that
+        specflux = cp.zeros((nspec, nwave))
+        specivar = cp.zeros((nspec, nwave))
+
+    #- TODO: add chi2pix, pixmask_fraction, optionally modelimage; see specter
+    result = dict(
+        flux = specflux,
+        ivar = specivar,
+        Rdiags = Rdiags,
+    )
+
+    return result

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -371,29 +371,26 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
     Options:
         bundlesize: size of fiber bundles; padding not needed on their edges
     """
-    timer = Timer()
+    # timer = Timer()
 
     specmin, nspecpad = get_spec_padding(ispec, nspec, bundlesize)
 
     #- Total number of wavelengths to be extracted, including padding
     nwavetot = nwave+2*wavepad
 
-    cuda.synchronize()
-    timer.split('init')
+    # timer.split('init')
 
     #- Get the projection matrix for the full wavelength range with padding
     A4, xyrange = projection_matrix(specmin, nspecpad,
         iwave-wavepad, nwave+2*wavepad, spots, corners)
-    cuda.synchronize()
-    timer.split('projection_matrix')
+    # timer.split('projection_matrix')
 
     xmin, xmax, ypadmin, ypadmax = xyrange
 
     #- But we only want to use the pixels covered by the original wavelengths
     #- TODO: this unnecessarily also re-calculates xranges
     xlo, xhi, ymin, ymax = get_xyrange(specmin, nspecpad, iwave, nwave, spots, corners)
-    cuda.synchronize()
-    timer.split('get_xyrange')
+    # timer.split('get_xyrange')
 
     ypadlo = ymin - ypadmin
     ypadhi = ypadmax - ymax
@@ -412,11 +409,9 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
 
     if (0 <= ymin) & (ymin+ny < image.shape[0]):
         xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
-        cuda.synchronize()
-        timer.split('ready for extraction')
+        # timer.split('ready for extraction')
         fx, ivarfx, R = xp_ex2d_patch(image[xyslice], imageivar[xyslice], A4)
-        cuda.synchronize()
-        timer.split('extracted patch')
+        # timer.split('extracted patch')
 
         #- Select the non-padded spectra x wavelength core region
         specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
@@ -434,8 +429,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
             for j in range(wavepad,wavepad+nwave):
                 # Rdiags dimensions [nspec, 2*ndiag+1, nwave]
                 Rdiags[i-i0, :, j-wavepad] = Rx[j-ndiag:j+ndiag+1, j]
-        cuda.synchronize()
-        timer.split('saved Rdiags')
+        # timer.split('saved Rdiags')
 
     else:
         #- TODO: this zeros out the entire patch if any of it is off the edge
@@ -449,8 +443,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
         ivar = specivar,
         Rdiags = Rdiags,
     )
-    cuda.synchronize()
-    timer.split('done')
-    timer.print_splits()
+    # timer.split('done')
+    # timer.print_splits()
 
     return result

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -56,7 +56,7 @@ class TestProjectionMatrix(unittest.TestCase):
 
     @unittest.skipIf(not gpu_available, 'gpu not available')
     def test_compare_gpu(self):
-        wavelengths = np.arange(6000.0, 6050.0, 1.0)
+        wavelengths = np.arange(5990.0, 6060.0, 1.0)
         spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
 
         spots_gpu = cp.asarray(spots)
@@ -64,9 +64,10 @@ class TestProjectionMatrix(unittest.TestCase):
 
         #- Compare projection matrix for a few combos of spectra & waves
         for ispec, nspec, iwave, nwave in (
-            (0, 5, 0, 25),
-            (10, 5, 20, 25),
-            (7, 3, 10, 12),
+            (0, 5, 10, 25),
+            (10, 5, 30, 25),
+            (7, 3, 20, 12),
+            (0, 6, 0, 70),
             ):
 
             #- cpu projection matrix
@@ -86,7 +87,7 @@ class TestProjectionMatrix(unittest.TestCase):
     def test_compare_specter(self):
         
         #- gpu_specter
-        wavelengths = np.arange(6000.0, 6050.0, 1.0)
+        wavelengths = np.arange(5990.0, 6060.0, 1.0)
         spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
 
         #- Load specter PSF
@@ -94,9 +95,10 @@ class TestProjectionMatrix(unittest.TestCase):
         
         #- Compare projection matrix for a few combos of spectra & waves
         for ispec, nspec, iwave, nwave in (
-            (0, 5, 0, 25),
-            (10, 5, 20, 25),
-            (7, 3, 10, 12),
+            (0, 5, 10, 25),
+            (10, 5, 30, 25),
+            (7, 3, 20, 12),
+            (0, 6, 0, 70),
             ):
         
             A4, xyrange = projection_matrix(


### PR DESCRIPTION
This PR enables the gpu code path in spex. The main missing piece was `gpu_specter.extract.gpu.ex2d_padded` which ended up being almost identical to the cpu version.

### Tests

In the process of testing this PR, I discovered a bug in `gpu_specter.extract.gpu.projection_matrix` that wasn't surfaced by the existing unit tests. I added a test case that fails before the fix and now passes after the fix. When I finally tracked down the bug, I was a little surprised that the existing tests were passing before.

I've also verified that the cpu/compare_specter tests all still pass using the master desi environment on cori.

The output values from the gpu version are nearly identical to the output from the cpu/mpi version (~99.96% of pixels are are within np.isclose).

### Performance

I've littered the code with timing statements to get a better sense of where time is being spent. The timing statements helped identify `cp.linalg.lstsq` as a hot spot in `gpu_specter.extract.both.xp_deconvolve`. Changing that to `cp.linalg.solve` brought the run time for a single frame using a single gpu down from ~10 min to ~4 min.

Overall the main bottleneck still seems to be the eigh function. The figure below shows a screenshot from the Nsight profiling tool. I've zoomed in to a section of the timeline that shows what's going on at the end of bundle and beginning of a new bundle. There is a little bit of data transfer between the device/host but it's pretty minor compared to the ~235 calls to ex2d_patch per bundle.

<img width="1052" alt="spex-gpu-bundle-boundary" src="https://user-images.githubusercontent.com/1648834/83595917-2b271080-a518-11ea-94db-a116dcb35987.png">