### PR TITLE
Refactor to allow multiple ranks per GPU with MPS

### DIFF
--- a/benchmarks/cpu_haswell.sh
+++ b/benchmarks/cpu_haswell.sh
@@ -47,7 +47,7 @@ basedir="/global/cfs/cdirs/desi/spectro/redux/andes"
 input="$basedir/preproc/20200219/00051060/preproc-r0-00051060.fits"
 psf="$basedir/exposures/20200219/00051060/psf-r0-00051060.fits"
 output="$SCRATCH/frame-r0-00051060.fits"
-cmd="spex --mpi -w 5761.0,7620.0,0.8 -i $input -p $psf -o $output"
+cmd="spex --mpi -w 5760.0,7620.0,0.8 -i $input -p $psf -o $output"
 
 # Perform benchmark
 start_time=$(_time)

--- a/bin/spex
+++ b/bin/spex
@@ -110,8 +110,7 @@ def main(args=None):
     if args.gpu:
         import cupy as cp
         device_count = cp.cuda.runtime.getDeviceCount()
-        assert size <= device_count
-        cp.cuda.Device(rank).use()
+        cp.cuda.Device(rank % device_count).use()
 
     #- For debugging convenience, default input image and psf
     if args.input is None:

--- a/bin/spex
+++ b/bin/spex
@@ -99,6 +99,8 @@ def main(args=None):
     #- Load MPI only if requested
     if args.mpi:
         from mpi4py import MPI
+        import dill
+        MPI.pickle.__init__(dill.dumps, dill.loads)
         comm = MPI.COMM_WORLD
         rank, size = comm.rank, comm.size
     else:
@@ -142,8 +144,8 @@ def main(args=None):
 
     if args.gpu:
         cp.cuda.nvtx.RangePush('copy imgpixels, imgivar to device')
-        imgpixels = cp.asarray(img['image'])
-        imgivar = cp.asarray(img['ivar'])
+        imgpixels = cp.asarray(imgpixels)
+        imgivar = cp.asarray(imgivar)
         cp.cuda.nvtx.RangePop()
 
     timer.split('load')

--- a/bin/spex
+++ b/bin/spex
@@ -105,6 +105,10 @@ def main(args=None):
         comm = None
         rank, size = 0, 1
 
+    if args.gpu:
+        import cupy as cp
+        cp.cuda.nvtx.RangePush('extract frame')
+
     #- For debugging convenience, default input image and psf
     if args.input is None:
         args.input = resource_filename('gpu_specter',
@@ -121,23 +125,33 @@ def main(args=None):
     timer.split('init')
 
     #- Load inputs
-    img = psf = None
+    img = psf = imgpixels = imgivar = None
     if rank == 0:
         log.info('Loading inputs')
         img = read_img(args.input)
+        imgpixels = img['image']
+        imgivar = img['ivar']
         psf = read_psf(args.psf)
         
     if comm is not None:
         if rank == 0:
             log.info('Broadcasting inputs to other MPI ranks')
-        img = comm.bcast(img, root=0)
+        imgpixels = comm.bcast(imgpixels, root=0)
+        imgivar = comm.bcast(imgivar, root=0)
         psf = comm.bcast(psf, root=0)
+
+    if args.gpu:
+        cp.cuda.nvtx.RangePush('copy imgpixels, imgivar to device')
+        imgpixels = cp.asarray(img['image'])
+        imgivar = cp.asarray(img['ivar'])
+        cp.cuda.nvtx.RangePop()
 
     timer.split('load')
 
     #- Perform extraction
     frame = extract_frame(
-        img, psf, args.bundlesize,         # input data
+        imgpixels, imgivar, psf,           # input data
+        args.bundlesize,                   #
         args.specmin, args.nspec,          # spectra to extract (specmin, specmin + nspec)
         args.wavelength,                   # wavelength range to extract
         args.nwavestep, args.nsubbundles,  # extraction algorithm parameters
@@ -147,9 +161,16 @@ def main(args=None):
     )
 
     timer.split('extract')
+    if args.gpu:
+        cp.cuda.nvtx.RangePop()
 
     #- Write output
     if rank == 0:
+
+        frame['imagehdr'] = img['imagehdr']
+        frame['fibermap'] = img['fibermap']
+        frame['fibermaphdr'] = img['fibermaphdr']
+
         if args.output is not None:
             log.info(f'Writing {args.output}')
             write_frame(args.output, frame)

--- a/bin/spex
+++ b/bin/spex
@@ -79,6 +79,16 @@ def check_input_options(args):
         msg = 'specmin ({}) must begin at a bundle boundary'.format(args.specmin)
         return False, msg
 
+    if args.gpu:
+        try:
+            import cupy as cp
+        except ImportError:
+            return False, 'cannot import module cupy'
+        if not cp.is_available():
+            return False, 'gpu is not available'
+        if cp.cuda.runtime.getDeviceCount() > 1 and not args.mpi:
+            return False, 'mpi is required to run with multiple gpu devices'
+
     return True, 'OK'
 
 def main(args=None):

--- a/bin/spex
+++ b/bin/spex
@@ -105,32 +105,6 @@ def main(args=None):
         comm = None
         rank, size = 0, 1
 
-    if args.gpu:
-        import cupy as cp
-        # TODO: specify number of gpus on command line?
-        device_count = cp.cuda.runtime.getDeviceCount()
-        cp.cuda.Device(rank % device_count).use()
-
-    #- Determine number of ranks per bundle
-    if args.gpu:
-        # divide evenly among gpus
-        group_size = size // device_count
-    else:
-        # default to one group with all MPI ranks
-        group_size = size
-
-    assert size % group_size == 0, 'Number of MPI ranks must be divisible by number of GPUs'
-
-    num_groups = size // group_size
-
-    group_rank, group = divmod(rank, num_groups)
-
-    if comm is not None and num_groups > 1:
-        group_comm = comm.Split(color=group, key=group_rank)
-        assert group_comm.rank == group_rank
-    else:
-        group_comm = None
-
     #- For debugging convenience, default input image and psf
     if args.input is None:
         args.input = resource_filename('gpu_specter',
@@ -153,27 +127,15 @@ def main(args=None):
         img = read_img(args.input)
         psf = read_psf(args.psf)
 
-        imgpixels = img['image']
-        imgivar = img['ivar']
-        
-    if comm is not None:
-        if rank == 0:
-            log.info('Broadcasting inputs to other MPI ranks')
-        imgpixels = comm.bcast(imgpixels, root=0)
-        imgivar = comm.bcast(imgivar, root=0)
-        psf = comm.bcast(psf, root=0)
-
     timer.split('load')
 
     #- Perform extraction
     frame = extract_frame(
-        imgpixels, imgivar, psf,           # input data
-        args.bundlesize,                   #
+        img, psf, args.bundlesize,         # input data
         args.specmin, args.nspec,          # spectra to extract (specmin, specmin + nspec)
         args.wavelength,                   # wavelength range to extract
         args.nwavestep, args.nsubbundles,  # extraction algorithm parameters
         comm, rank, size,                  # mpi parameters
-        group_comm, group,
         args.gpu,                          # gpu parameters
         args.loglevel,                     # log
     )
@@ -182,10 +144,6 @@ def main(args=None):
 
     #- Write output
     if rank == 0:
-
-        frame['imagehdr'] = img['imagehdr']
-        frame['fibermap'] = img['fibermap']
-        frame['fibermaphdr'] = img['fibermaphdr']
 
         if args.output is not None:
             log.info(f'Writing {args.output}')

--- a/bin/spex
+++ b/bin/spex
@@ -99,8 +99,6 @@ def main(args=None):
     #- Load MPI only if requested
     if args.mpi:
         from mpi4py import MPI
-        import dill
-        MPI.pickle.__init__(dill.dumps, dill.loads)
         comm = MPI.COMM_WORLD
         rank, size = comm.rank, comm.size
     else:

--- a/bin/spex
+++ b/bin/spex
@@ -80,7 +80,7 @@ def check_input_options(args):
     if args.specmin % args.bundlesize != 0:
         msg = 'specmin ({}) must begin at a bundle boundary'.format(args.specmin)
         return False, msg
-    
+
     return True, 'OK'
 
 def main(args=None):
@@ -101,8 +101,6 @@ def main(args=None):
     #- Load MPI only if requested
     if args.mpi:
         from mpi4py import MPI
-        import dill
-        MPI.pickle.__init__(dill.dumps, dill.loads)
         comm = MPI.COMM_WORLD
         rank, size = comm.rank, comm.size
     else:
@@ -136,7 +134,7 @@ def main(args=None):
     group = rank % num_groups
     group_rank = rank // num_groups
 
-    if comm is not None:
+    if comm is not None and num_groups > 1:
         group_comm = comm.Split(color=group, key=group_rank)
         assert group_comm.rank == group_rank
     else:

--- a/bin/spex
+++ b/bin/spex
@@ -44,6 +44,8 @@ def parse(options=None):
     parser.add_argument("--loglevel", default='info', help='log print level (debug,info,warn,error)')
     parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
     parser.add_argument("--gpu", action="store_true", help="Use GPU for extraction")
+    parser.add_argument("--ranks-per-bundle", type=int, required=False, default=None,
+                        help="Number of mpi ranks per bundle")
     # parser.add_argument("--decorrelate-fibers", action="store_true", help="Not recommended")
     # parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
     # parser.add_argument("--psferr", type=float, default=None, required=False,
@@ -109,8 +111,36 @@ def main(args=None):
 
     if args.gpu:
         import cupy as cp
+        # TODO: specify number of gpus on command line?
         device_count = cp.cuda.runtime.getDeviceCount()
         cp.cuda.Device(rank % device_count).use()
+
+    #- Determine number of ranks per bundle
+    if args.ranks_per_bundle is not None:
+        # use argument if specified
+        group_size = args.ranks_per_bundle
+    elif args.gpu:
+        # divide evenly among gpus
+        group_size = size // device_count
+    else:
+        # default to one group with all MPI ranks
+        group_size = size
+
+    assert size % group_size == 0, 'Number of MPI ranks must be divisible by --ranks-per-bundle'
+
+    num_groups = size // group_size
+
+    if args.gpu:
+        assert num_groups == device_count, 'Number of MPI groups must match number of GPU devices'
+
+    group = rank % num_groups
+    group_rank = rank // num_groups
+
+    if comm is not None:
+        group_comm = comm.Split(color=group, key=group_rank)
+        assert group_comm.rank == group_rank
+    else:
+        group_comm = None
 
     #- For debugging convenience, default input image and psf
     if args.input is None:
@@ -154,6 +184,7 @@ def main(args=None):
         args.wavelength,                   # wavelength range to extract
         args.nwavestep, args.nsubbundles,  # extraction algorithm parameters
         comm, rank, size,                  # mpi parameters
+        group_comm, group,
         args.gpu,                          # gpu parameters
         args.loglevel,                     # log
     )

--- a/bin/spex
+++ b/bin/spex
@@ -109,7 +109,9 @@ def main(args=None):
 
     if args.gpu:
         import cupy as cp
-        cp.cuda.nvtx.RangePush('extract frame')
+        device_count = cp.cuda.runtime.getDeviceCount()
+        assert size <= device_count
+        cp.cuda.Device(rank).use()
 
     #- For debugging convenience, default input image and psf
     if args.input is None:
@@ -131,9 +133,10 @@ def main(args=None):
     if rank == 0:
         log.info('Loading inputs')
         img = read_img(args.input)
+        psf = read_psf(args.psf)
+
         imgpixels = img['image']
         imgivar = img['ivar']
-        psf = read_psf(args.psf)
         
     if comm is not None:
         if rank == 0:
@@ -141,12 +144,6 @@ def main(args=None):
         imgpixels = comm.bcast(imgpixels, root=0)
         imgivar = comm.bcast(imgivar, root=0)
         psf = comm.bcast(psf, root=0)
-
-    if args.gpu:
-        cp.cuda.nvtx.RangePush('copy imgpixels, imgivar to device')
-        imgpixels = cp.asarray(imgpixels)
-        imgivar = cp.asarray(imgivar)
-        cp.cuda.nvtx.RangePop()
 
     timer.split('load')
 
@@ -163,8 +160,6 @@ def main(args=None):
     )
 
     timer.split('extract')
-    if args.gpu:
-        cp.cuda.nvtx.RangePop()
 
     #- Write output
     if rank == 0:

--- a/bin/spex
+++ b/bin/spex
@@ -44,8 +44,6 @@ def parse(options=None):
     parser.add_argument("--loglevel", default='info', help='log print level (debug,info,warn,error)')
     parser.add_argument("--mpi", action="store_true", help="Use MPI for parallelism")
     parser.add_argument("--gpu", action="store_true", help="Use GPU for extraction")
-    parser.add_argument("--ranks-per-bundle", type=int, required=False, default=None,
-                        help="Number of mpi ranks per bundle")
     # parser.add_argument("--decorrelate-fibers", action="store_true", help="Not recommended")
     # parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
     # parser.add_argument("--psferr", type=float, default=None, required=False,
@@ -101,6 +99,8 @@ def main(args=None):
     #- Load MPI only if requested
     if args.mpi:
         from mpi4py import MPI
+        import dill
+        MPI.pickle.__init__(dill.dumps, dill.loads)
         comm = MPI.COMM_WORLD
         rank, size = comm.rank, comm.size
     else:
@@ -114,25 +114,18 @@ def main(args=None):
         cp.cuda.Device(rank % device_count).use()
 
     #- Determine number of ranks per bundle
-    if args.ranks_per_bundle is not None:
-        # use argument if specified
-        group_size = args.ranks_per_bundle
-    elif args.gpu:
+    if args.gpu:
         # divide evenly among gpus
         group_size = size // device_count
     else:
         # default to one group with all MPI ranks
         group_size = size
 
-    assert size % group_size == 0, 'Number of MPI ranks must be divisible by --ranks-per-bundle'
+    assert size % group_size == 0, 'Number of MPI ranks must be divisible by number of GPUs'
 
     num_groups = size // group_size
 
-    if args.gpu:
-        assert num_groups == device_count, 'Number of MPI groups must match number of GPU devices'
-
-    group = rank % num_groups
-    group_rank = rank // num_groups
+    group_rank, group = divmod(rank, num_groups)
 
     if comm is not None and num_groups > 1:
         group_comm = comm.Split(color=group, key=group_rank)

--- a/bin/spex
+++ b/bin/spex
@@ -121,7 +121,7 @@ def main(args=None):
     timer.split('init')
 
     #- Load inputs
-    img = psf = imgpixels = imgivar = None
+    img = psf = None
     if rank == 0:
         log.info('Loading inputs')
         img = read_img(args.input)
@@ -144,7 +144,6 @@ def main(args=None):
 
     #- Write output
     if rank == 0:
-
         if args.output is not None:
             log.info(f'Writing {args.output}')
             write_frame(args.output, frame)

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -212,6 +212,11 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
         fluxivar.append(results['ivar'])
         resolution.append(results['Rdiags'])
 
+    if gpu:
+        flux = cp.asnumpy(cp.array(flux, dtype=cp.float64))
+        fluxivar = cp.asnumpy(cp.array(fluxivar, dtype=cp.float64))
+        resolution = cp.asnumpy(cp.array(resolution, dtype=cp.float64))
+
     def gather_ndarray(sendbuf, comm, rank, root=0):
         sendbuf = np.array(sendbuf)
         shape = sendbuf.shape

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -212,7 +212,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             patches.append(patch)
 
     if rank == 0:
-        log.info(f'Dividing {len(patches)} between {size} ranks')
+        log.info(f'Dividing {len(patches)} patches between {size} ranks')
 
     timer.split('organize patches')
 

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -238,9 +238,9 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
 
             # gather to root MPI rank
             patches = comm.gather(patches, root=0)
-            flux = gather_ndarray(flux, comm)
-            fluxivar = gather_ndarray(fluxivar, comm)
-            resolution = gather_ndarray(resolution, comm)
+            flux = gather_ndarray(flux, comm, root=0)
+            fluxivar = gather_ndarray(fluxivar, comm, root=0)
+            resolution = gather_ndarray(resolution, comm, root=0)
 
             if rank == 0:
                 # unpack patches

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -14,35 +14,7 @@ except ImportError:
 from gpu_specter.util import get_logger
 from gpu_specter.util import get_array_module
 from gpu_specter.util import Timer
-
-def gather_ndarray(sendbuf, comm, root=0):
-    """Gather multidimensional ndarray objects to one process from
-    all other processes in a group.
-
-    Args:
-        sendbuf: multidimensional ndarray
-        comm: mpi communicator
-        root: rank of receiving process
-    Returns:
-        recvbuf: A stacked multidemsional ndarray if comm.rank == root, otherwise None.
-
-    """
-    rank = comm.rank
-    # Save shape and flatten input array
-    sendbuf = np.array(sendbuf)
-    shape = sendbuf.shape
-    sendbuf = sendbuf.ravel()
-    # Collect local array sizes using the high-level mpi4py gather
-    sendcounts = np.array(comm.gather(len(sendbuf), root))
-    if rank == root:
-        recvbuf = np.empty(sum(sendcounts), dtype=sendbuf.dtype)
-    else:
-        recvbuf = None
-    comm.Gatherv(sendbuf=sendbuf, recvbuf=(recvbuf, sendcounts), root=root)
-    if rank == root:
-        # Reshape output before returning
-        recvbuf = recvbuf.reshape((-1,) + shape[1:])
-    return recvbuf
+from gpu_specter.util import gather_ndarray
 
 class Patch(object):
     def __init__(self, ispec, iwave, bspecmin, nspectra_per_patch, nwavestep, wavepad, nwave,

--- a/py/gpu_specter/util.py
+++ b/py/gpu_specter/util.py
@@ -13,6 +13,34 @@ try:
 except ImportError:
     pass
 
+def gather_ndarray(sendbuf, comm, root=0):
+    """Gather multidimensional ndarray objects to one process from all other processes in a group.
+
+    Args:
+        sendbuf: multidimensional ndarray
+        comm: mpi communicator
+        root: rank of receiving process
+    Returns:
+        recvbuf: A stacked multidemsional ndarray if comm.rank == root, otherwise None.
+
+    """
+    rank = comm.rank
+    # Save shape and flatten input array
+    sendbuf = np.array(sendbuf)
+    shape = sendbuf.shape
+    sendbuf = sendbuf.ravel()
+    # Collect local array sizes using the high-level mpi4py gather
+    sendcounts = np.array(comm.gather(len(sendbuf), root))
+    if rank == root:
+        recvbuf = np.empty(sum(sendcounts), dtype=sendbuf.dtype)
+    else:
+        recvbuf = None
+    comm.Gatherv(sendbuf=sendbuf, recvbuf=(recvbuf, sendcounts), root=root)
+    if rank == root:
+        # Reshape output before returning
+        recvbuf = recvbuf.reshape((-1,) + shape[1:])
+    return recvbuf
+
 def get_array_module(x):
     """Returns the array module for arguments.
 


### PR DESCRIPTION
This PR makes some modifications to allow for multiple GPUs and multiple MPI ranks per GPU. There are essentially 5 different code execution paths intertwined together now (new paths in bold):

 * No MPI 
 * No MPI w/ GPU
 * MPI 
 * **MPI w/ GPU (nranks/ngpu = 1)** 
 * **MPI w/ GPU (nranks/ngpu > 1)**

The code is working with up 4 ranks per GPU, although performance benefit after 2 ranks per GPU is negligible.

![image](https://user-images.githubusercontent.com/1648834/84464739-34a42d00-ac2a-11ea-8d41-cda8b97f40ff.png)

In order to work around some memory errors that were occurring during MPI communication, I implemented `gpu_specter.util.gather_ndarray` to gather multidimensional numpy arrays directly (without serialization) using a vector variant gather operation.