### PR TITLE
Add instructions for running on GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,99 @@
 
 Scratch work for porting spectroperfectionism extractions to GPUs
 
-# Directions to run cpu version (currently only working version)
+# Example usage at NERSC
 
-## Set up the environment; there are multiple correct ways to do this
+## CPU
 
 ```
-source /global/cfs/cdirs/desi/software/desi_environment.sh master
-git clone https://github.com/sjbailey/gpu_specter
+# these instructions assume we're at the top level of this repo
 cd gpu_specter
-git checkout refactor
+
+# request an interactive node
+salloc -N 1 -C haswell -t 60 -q interactive
+
+# setup environment
+source /global/cfs/cdirs/desi/software/desi_environment.sh master
 export PATH=$(pwd)/bin:$PATH
 export PYTHONPATH=$(pwd)/py:$PYTHONPATH
+
+# prepare command line arguments
+basedir=/global/cfs/cdirs/desi/spectro/redux/andes
+args="-w 5760.0,7620.0,0.8 -i $basedir/preproc/20200219/00051060/preproc-r0-00051060.fits -p $basedir/exposures/20200219/00051060/psf-r0-00051060.fits"
+
+# run spex
+srun -n 32 -c 2 bin/spex --mpi -o $SCRATCH/spex_haswell_mpi32_gpu0.fits $args
+
+# for comparison, run desi_extract_spectra
+srun -n 32 -c 2 desi_extract_spectra --mpi -o $SCRATCH/desi_haswell_mpi32_gpu0.fits $args
 ```
 
-## Get an interactive cpu node
+## GPU
+
+Use the [these instructions](doc/how-to-build-gpu-conda-env.md) for building a gpu conda environment.
+
+### Single GPU
 
 ```
-salloc -N 1 -C haswell -t 60 -q interactive
-basedir=/global/cfs/cdirs/desi/spectro/redux/daily/
+cd gpu_specter
+module load python esslurm cuda
+salloc -C gpu -N 1 -G 1 -c 10 -t 60 -A m1759
+
+source activate desi-gpu
+export PATH=$(pwd)/bin:$PATH
+export PYTHONPATH=$(pwd)/py:$PYTHONPATH
+
+module load gcc/7.3.0 mvapich2
+export MV2_USE_CUDA=1
+export MV2_ENABLE_AFFINITY=0
+export LD_PRELOAD=$MVAPICH2_DIR/lib/libmpi.so
+
+export OMP_NUM_THREADS=1
+export OMP_PLACES=threads
+export OMP_PROC_BIND=spread
+
+basedir=/global/cfs/cdirs/desi/spectro/redux/andes
+args="-w 5760.0,7620.0,0.8 -i $basedir/preproc/20200219/00051060/preproc-r0-00051060.fits -p $basedir/exposures/20200219/00051060/psf-r0-00051060.fits"
+
+# 0 GPU (CPU only)
+srun -n 5 -c 2 --cpu-bind=cores bin/spex --mpi -o $SCRATCH/spex_skylake_mpi5_gpu0.fits $args
+
+# 1 GPU (single process, no MPI)
+srun -n 1 -c 2 --cpu-bind=cores bin/spex --gpu -o $SCRATCH/spex_skylake_mpi0_gpu1.fits $args
+
+# 1 GPU + MPI
+srun -n 2 -c 2 --cpu-bind=cores bin/spex --mpi --gpu -o $SCRATCH/spex_skylake_mpi2_gpu1.fits $args
+
+# 1 GPU + MPI + MPS
+srun -n 2 -c 2 --cpu-bind=cores bin/mps-wrapper bin/spex --mpi --gpu -o $SCRATCH/spex_skylake_mpi2_gpu1_mps.fits $args
 ```
 
-## Run spex (just over 1 min for a full frame)
+### Multi GPU 
 
 ```
-time srun -n 32 -c 2 spex --mpi -w 5760.0,7620.0,0.8 \
--i $basedir/preproc/20200219/00051060/preproc-r0-00051060.fits \
--p $basedir/exposures/20200219/00051060/psf-r0-00051060.fits \
--o $SCRATCH/blat.fits
-```
+cd gpu_specter
+module load python esslurm cuda
+salloc -C gpu -N 1 -G 2 -c 20 -t 60 -A m1759
 
-# TODO: directions to run gpu version
+source activate desi-gpu
+export PATH=$(pwd)/bin:$PATH
+export PYTHONPATH=$(pwd)/py:$PYTHONPATH
+
+module load gcc/7.3.0 mvapich2
+export MV2_USE_CUDA=1
+export MV2_ENABLE_AFFINITY=0
+export LD_PRELOAD=$MVAPICH2_DIR/lib/libmpi.so
+
+export OMP_NUM_THREADS=1
+export OMP_PLACES=threads
+export OMP_PROC_BIND=spread
+
+basedir=/global/cfs/cdirs/desi/spectro/redux/andes
+args="-w 5760.0,7620.0,0.8 -i $basedir/preproc/20200219/00051060/preproc-r0-00051060.fits -p $basedir/exposures/20200219/00051060/psf-r0-00051060.fits"
+
+### 2 GPU + MPI
+srun -n 2 -c 2 --cpu-bind=cores bin/spex --mpi --gpu -o $SCRATCH/spex_skylake_mpi2_gpu2.fits $args
+
+### 2 GPU + MPI + MPS
+srun -n 4 -c 2 --cpu-bind=cores bin/mps-wrapper bin/spex --mpi --gpu -o $SCRATCH/spex_skylake_mpi4_gpu2_mps.fits $args
+```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use the [these instructions](doc/how-to-build-gpu-conda-env.md) for building a g
 
 ```
 cd gpu_specter
-module load python esslurm cuda
+module load python esslurm cuda/10.2.89
 salloc -C gpu -N 1 -G 1 -c 10 -t 60 -A m1759
 
 source activate desi-gpu
@@ -73,7 +73,7 @@ srun -n 2 -c 2 --cpu-bind=cores bin/mps-wrapper bin/spex --mpi --gpu -o $SCRATCH
 
 ```
 cd gpu_specter
-module load python esslurm cuda
+module load python esslurm cuda/10.2.89
 salloc -C gpu -N 1 -G 2 -c 20 -t 60 -A m1759
 
 source activate desi-gpu

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ export OMP_PROC_BIND=spread
 basedir=/global/cfs/cdirs/desi/spectro/redux/andes
 args="-w 5760.0,7620.0,0.8 -i $basedir/preproc/20200219/00051060/preproc-r0-00051060.fits -p $basedir/exposures/20200219/00051060/psf-r0-00051060.fits"
 
-### 2 GPU + MPI
+# 2 GPU + MPI
 srun -n 2 -c 2 --cpu-bind=cores bin/spex --mpi --gpu -o $SCRATCH/spex_skylake_mpi2_gpu2.fits $args
 
-### 2 GPU + MPI + MPS
+# 2 GPU + MPI + MPS
 srun -n 4 -c 2 --cpu-bind=cores bin/mps-wrapper bin/spex --mpi --gpu -o $SCRATCH/spex_skylake_mpi4_gpu2_mps.fits $args
 ```

--- a/bin/mps-wrapper
+++ b/bin/mps-wrapper
@@ -1,0 +1,26 @@
+#!/bin/bash
+# 
+# Example usage:  
+# > srun -n 2 -c 1 mps-wrapper command arg1 arg2 ...
+#
+
+# https://docs.nvidia.com/deploy/mps/index.html
+export CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps
+export CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-log
+
+# https://docs.nvidia.com/deploy/mps/index.html#topic_3_3_5_2
+# export CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=$((100 / $SLURM_NTASKS))
+# export CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=$((200 / $SLURM_NTASKS))
+
+if [ $SLURM_PROCID -eq 0 ]; then
+    nvidia-cuda-mps-control -d
+fi
+
+sleep 5
+
+# run the command
+"$@"
+
+if [ $SLURM_PROCID -eq 0 ]; then
+    echo quit | nvidia-cuda-mps-control
+fi


### PR DESCRIPTION
This PR updates the main README to include instructions for running on the GPU.

It also adds a wrapper script `bin/mps-wrapper` (useful when running with multiple MPI ranks per GPU).