### PR TITLE
Add unit test for extract_frame

### DIFF
--- a/bin/compare-frame
+++ b/bin/compare-frame
@@ -50,7 +50,9 @@ def plot_diff_2d(diff, wave, output):
 def plot_diff_1d(diff, wave, output):
     fig, ax = plt.subplots(figsize=(8, 6))
     # pick some arbitrary spectra
-    for ispec in (np.arange(20)*25 + 7):
+    size = len(diff)
+    step = size // 5
+    for ispec in np.arange(0, size, step):
         ax.plot(wave, 1e2*diff[ispec] + ispec, marker='.', markersize=1, lw=0)
 
     ax.set_ylabel('1e2*diff (offset by spectrum index)')
@@ -80,7 +82,7 @@ def main():
     assert a['resolution'].shape == b['resolution'].shape
 
     # compare wave
-    assert np.all(a['wave'] == b['wave'])
+    print('wave (allclose):', np.allclose(a['wave'], b['wave']))
 
     nspec = a['flux'].shape[0]
     wave = a['wave']

--- a/bin/compare-frame
+++ b/bin/compare-frame
@@ -89,12 +89,21 @@ def main():
     wmin, wmax = wave[0], wave[-1]
     nwave = len(wave)
 
-    template = '{label:>10}: {fraction:7.2%}'
+    template = '{label:>16}: {fraction:7.2%}'
+
+    eps_single = np.finfo(np.float32).eps
+    eps_double = np.finfo(np.float64).eps
 
     # compare flux
     print('(f_a, f_b):')
     isclose = np.average(np.isclose(a['flux'], b['flux']))
     print(template.format(label='isclose', fraction=isclose))
+
+    isclose_single = np.average(np.isclose(a['flux'], b['flux'], atol=0, rtol=eps_single))
+    print(template.format(label='isclose_single', fraction=isclose_single))
+
+    isclose_double = np.average(np.isclose(a['flux'], b['flux'], atol=0, rtol=eps_double))
+    print(template.format(label='isclose_double', fraction=isclose_double))
 
     print('(f_a - f_b)/sqrt(var_a + var_b):')
     diff = (a['flux'] - b['flux']) / np.sqrt(1.0/a['ivar'] + 1.0/b['ivar'])
@@ -114,6 +123,12 @@ def main():
     isclose = np.average(np.isclose(a['ivar'], b['ivar']))
     print(template.format(label='isclose', fraction=isclose))
 
+    isclose_single = np.average(np.isclose(a['ivar'], b['ivar'], atol=0, rtol=eps_single))
+    print(template.format(label='isclose_single', fraction=isclose_single))
+
+    isclose_double = np.average(np.isclose(a['ivar'], b['ivar'], atol=0, rtol=eps_double))
+    print(template.format(label='isclose_double', fraction=isclose_double))
+
     print('(sigma_a - sigma_b)/sqrt(var_a + var_b):')
     avar = 1.0/a['ivar']
     bvar = 1.0/b['ivar']
@@ -128,6 +143,12 @@ def main():
     print('(resolution_a, resolution_b):')
     isclose = np.average(np.isclose(a['resolution'], b['resolution']))
     print(template.format(label='isclose', fraction=isclose))
+
+    isclose_single = np.average(np.isclose(a['resolution'], b['resolution'], atol=0, rtol=eps_single))
+    print(template.format(label='isclose_single', fraction=isclose_single))
+
+    isclose_double = np.average(np.isclose(a['resolution'], b['resolution'], atol=0, rtol=eps_double))
+    print(template.format(label='isclose_double', fraction=isclose_double))
 
 
 if __name__ == "__main__":

--- a/bin/compare-frame
+++ b/bin/compare-frame
@@ -77,6 +77,7 @@ def main():
     assert a['wave'].shape == b['wave'].shape
     assert a['flux'].shape == b['flux'].shape
     assert a['ivar'].shape == b['ivar'].shape
+    assert a['resolution'].shape == b['resolution'].shape
 
     # compare wave
     assert np.all(a['wave'] == b['wave'])
@@ -120,6 +121,11 @@ def main():
     for threshold in thresholds:
         fraction = np.average(np.abs(diff).ravel() < threshold)
         print(template.format(label=threshold, fraction=fraction))
+
+    # compare resolution
+    print('(resolution_a, resolution_b):')
+    isclose = np.average(np.isclose(a['resolution'], b['resolution']))
+    print(template.format(label='isclose', fraction=isclose))
 
 
 if __name__ == "__main__":

--- a/bin/compare-frame
+++ b/bin/compare-frame
@@ -60,6 +60,46 @@ def plot_diff_1d(diff, wave, output):
     plt.savefig(output + '-1D.png', bbox_inches='tight', dpi=100)
 
 
+def compare_array(x, y, atol=0, rtol=1.e-8):
+
+    print(f'Checking tolerance rtol={rtol}, atol={atol}')
+
+    ynonzero = y != 0
+    xnonzero = x != 0
+
+    if not np.array_equal(xnonzero, ynonzero):
+        print(f"Nonzero x: {np.sum(xnonzero)} / {x.size}")
+        print(f"Nonzero y: {np.sum(ynonzero)} / {y.size}")
+    nonzero = xnonzero & ynonzero
+
+    adiff = np.abs(x[nonzero] - y[nonzero])
+    max_adiff = np.max(adiff)
+    print(f'Max absolute difference: {max_adiff}')
+    if atol > 0:
+        amismatch = adiff > atol
+        nmismatch = np.sum(amismatch)
+        mismatch_fraction = nmismatch / x.size
+        if nmismatch:
+            print(f'Mismatched elements: {nmismatch} / {x.size} ({mismatch_fraction:.3g}%)')
+            print('x: ', repr(x[amismatch]))
+            print('y: ', repr(y[amismatch]))
+
+    yrdiff = (adiff / np.abs(y[nonzero]))
+    xrdiff = (adiff / np.abs(x[nonzero]))
+    max_rdiff = max(np.max(xrdiff), np.max(yrdiff))
+    print(f'Max relative difference: {max_rdiff}')
+    if rtol > 0:
+        rmismatch = (xrdiff > rtol) | (yrdiff > rtol)
+        nmismatch = np.sum(rmismatch)
+        mismatch_fraction = nmismatch / x.size
+        if nmismatch > 0:
+            print(f'Mismatched elements: {nmismatch} / {x.size} ({mismatch_fraction:.3g}%)')
+            print('x: ', repr(x[nonzero][rmismatch]))
+            print('y: ', repr(y[nonzero][rmismatch]))
+    print()
+
+
+
 def main():
     parser = argparse.ArgumentParser(description='Process some integers.')
     parser.add_argument('-a', '--filename-a', type=str, required=True,
@@ -105,6 +145,8 @@ def main():
     isclose_double = np.average(np.isclose(a['flux'], b['flux'], atol=0, rtol=eps_double))
     print(template.format(label='isclose_double', fraction=isclose_double))
 
+    compare_array(a['flux'], b['flux'], rtol=1e-5)
+
     print('(f_a - f_b)/sqrt(var_a + var_b):')
     diff = (a['flux'] - b['flux']) / np.sqrt(1.0/a['ivar'] + 1.0/b['ivar'])
     tstart, tstop = -5, 0
@@ -112,7 +154,6 @@ def main():
     for threshold in thresholds:
         fraction = np.average(np.abs(diff).ravel() < threshold)
         print(template.format(label=threshold, fraction=fraction))
-
 
     if args.output is not None:
         plot_diff_2d(diff, wave, args.output)

--- a/bin/compare-specter
+++ b/bin/compare-specter
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+
+import numpy as np
+
+from gpu_specter.io import read_img, read_psf
+from gpu_specter.core import extract_frame
+
+try:
+    import specter.psf
+    import specter.extract
+    specter_available = True
+except ImportError:
+    specter_available = False
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", type=str, required=True,
+                        help="input image")
+    parser.add_argument("-p", "--psf", type=str, required=True,
+                        help="input psf file")
+    parser.add_argument("-s", "--specmin", type=int, required=False, default=0,
+                        help="first spectrum to extract")
+    parser.add_argument("-n", "--nspec", type=int, required=False, default=500,
+                        help="number of spectra to extract")
+    parser.add_argument("--bundlesize", type=int, required=False, default=25,
+                        help="number of spectra per bundle")
+    parser.add_argument("--nsubbundles", type=int, required=False, default=5,
+                        help="number of extraction sub-bundles")
+    parser.add_argument("-w", "--wavelength", type=str, required=False, default='5760.0,7620.0,0.8',
+                        help="wavemin,wavemax,dw")
+    parser.add_argument("--nwavestep", type=int, required=False, default=50,
+                        help="number of wavelength steps per divide-and-conquer extraction step")
+    parser.add_argument("--pull-threshold", type=float, required=False, default=0.01,
+                        help="pull distribution threshold to use for comparing results")
+    args = parser.parse_args()
+
+    if not specter_available:
+        raise RuntimeError('Could not import specter')
+
+    psf = read_psf(args.psf)
+    img = read_img(args.input)
+
+    frame_spex = extract_frame(
+        img, psf, args.bundlesize,
+        args.specmin, args.nspec,
+        wavelength=args.wavelength,
+        nwavestep=args.nwavestep, nsubbundles=args.nsubbundles,
+        comm=None, rank=0, size=1,
+        gpu=None,
+        loglevel='INFO',
+    )
+
+    specter_psf = specter.psf.load_psf(args.psf)
+
+    # use the same wavelength array 
+    wavelengths = frame_spex['wave']
+
+    frame_specter = specter.extract.ex2d(
+        img['image'], img['ivar'], specter_psf, 
+        args.specmin, args.nspec, wavelengths, 
+        xyrange=None, regularize=0.0, ndecorr=False,
+        bundlesize=args.bundlesize, nsubbundles=args.nsubbundles,
+        wavesize=args.nwavestep, 
+        full_output=True, verbose=True,
+        debug=False, psferr=None,
+    )
+
+    diff = frame_spex['specflux'] - frame_specter['flux']
+    norm = np.sqrt(1.0/frame_spex['specivar'] + 1.0/frame_specter['ivar'])
+    pull = diff/norm
+    pull_fraction = np.average(np.abs(pull).ravel() < args.pull_threshold)
+
+    print(f'fraction of pixels with (pull < {args.pull_threshold}): {pull_fraction}')
+
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -6,6 +6,18 @@ Run unit test suite using:
 python setup.py test
 ```
 
+Note that `python setup.py test` triggers a deprecation warning. An altenative:
+
+```
+python -m unittest --verbose gpu_specter.test.test_suite
+```
+
+On a gpu node:
+
+```
+srun python -m unittest --verbose gpu_specter.test.test_suite
+```
+
 ## Strict regression test
     
 Use to confirm that changes do not affect the output. 
@@ -32,34 +44,33 @@ This test is more nuanced than the strict regression test.
 
 Example comparison between `spex` and `desi_extract_spectra`
 
-Generate output files:
+Use the instructions from the top-level README to generate the output "frame" files:
+ * `$SCRATCH/spex_haswell_mpi32_gpu0.fits` 
+ * `$SCRATCH/desi_haswell_mpi32_gpu0.fits`
+
+Compare the results using `bin/compare-frame`:
 
 ```
-cd gpu_specter
-source /global/cfs/cdirs/desi/software/desi_environment.sh master
-export PATH=$(pwd)/bin:$PATH
-export PYTHONPATH=$(pwd)/py:$PYTHONPATH
-
-salloc -N 1 -C haswell -t 60 -q interactive
-
-basedir=/global/cfs/cdirs/desi/spectro/redux/andes
-args="-w 5760.0,7620.0,0.8 -i $basedir/preproc/20200219/00051060/preproc-r0-00051060.fits -p $basedir/exposures/20200219/00051060/psf-r0-00051060.fits"
-
-srun -n 32 -c 2 desi_extract_spectra --mpi -o $SCRATCH/desi_extract.fits $args
-srun -n 32 -c 2 bin/spex --mpi -o $SCRATCH/spex_extract.fits $args
-```
-
-Example parity test output:
-
-```
-$ python bin/compare-frame -a $SCRATCH/spex_extract.fits -b $SCRATCH/desi_extract.fits
+$ python bin/compare-frame -a $SCRATCH/spex_haswell_mpi32_gpu0.fits -b $SCRATCH/desi_haswell_mpi32_gpu0.fits
+wave (allclose): True
 (f_a, f_b):
-  isclose:   70.17%
+   isclose:  70.17%
 (f_a - f_b)/sqrt(var_a + var_b):
-    1e-05:   60.38%
-   0.0001:   73.73%
-    0.001:   84.80%
-     0.01:   94.74%
-      0.1:   99.88%
-      1.0:  100.00%
+     1e-05:  60.38%
+    0.0001:  73.73%
+     0.001:  84.80%
+      0.01:  94.74%
+       0.1:  99.88%
+       1.0: 100.00%
+(ivar_a, ivar_b):
+   isclose:  81.98%
+(sigma_a - sigma_b)/sqrt(var_a + var_b):
+     1e-05:  84.95%
+    0.0001:  92.98%
+     0.001:  99.14%
+      0.01:  99.99%
+       0.1:  99.99%
+       1.0: 100.00%
+(resolution_a, resolution_b):
+   isclose:  81.34%
 ```

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -417,7 +417,8 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             bundlesize=bundlesize, nsubbundles=nsubbundles,
             nwavestep=nwavestep, wavepad=wavepad,
             comm=bundle_comm,
-            gpu=gpu
+            gpu=gpu,
+            loglevel=loglevel,
         )
         if gpu:
             cp.cuda.nvtx.RangePop()

--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -63,7 +63,7 @@ def xp_decorrelate(iCov, debug=False):
     """
     xp = get_array_module(iCov)
     # Calculate the matrix square root of iCov to diagonalize the flux errors.
-    u, v = xp.linalg.eigh((iCov + iCov.T)/2.)
+    u, v = xp.linalg.eigh(iCov)
     # Check that all eigenvalues are positive.
     assert not debug or xp.all(u > 0), 'Found some negative iCov eigenvalues.'
     # Check that the eigenvectors are orthonormal so that vt.v = 1

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -210,7 +210,7 @@ def calc_pgh(ispec, wavelengths, psfparams):
 
 
 @cuda.jit()
-def _multispot(pGHx, pGHy, ghc, mspots):
+def _multispot(pGHx, pGHy, ghc, spots):
     nx = pGHx.shape[-1]
     ny = pGHy.shape[-1]
     nwave = pGHx.shape[1]
@@ -230,7 +230,18 @@ def _multispot(pGHx, pGHy, ghc, mspots):
                 c = ghc[i,j,iwave]
                 for iy in range(len(py)):
                     for ix in range(len(px)):
-                        mspots[iwave, iy, ix] += c * py[iy] * px[ix]
+                        spots[iwave, iy, ix] += c * py[iy] * px[ix]
+
+def multispot(pGHx, pGHy, ghc):
+    nx = pGHx.shape[-1]
+    ny = pGHy.shape[-1]
+    nwave = pGHx.shape[1]
+    blocksize = 256
+    numblocks = (nwave + blocksize - 1) // blocksize
+    spots = cp.zeros((nwave, ny, nx)) #empty every time!
+    _multispot[numblocks, blocksize](pGHx, pGHy, ghc, spots)
+    return spots
+
 
 def get_spots(specmin, nspec, wavelengths, psfdata):
     '''Calculate PSF spots for the specified spectra and wavelengths
@@ -251,15 +262,9 @@ def get_spots(specmin, nspec, wavelengths, psfdata):
     nx = 2*p['HSIZEX']+1
     ny = 2*p['HSIZEY']+1
     spots = cp.zeros((nspec, nwave, ny, nx))
-    #use mark's numblocks and blocksize method
-    blocksize = 256
-    numblocks = (nwave + blocksize - 1) // blocksize
     for ispec in range(nspec):
         pGHx, pGHy = calc_pgh(ispec, wavelengths, p)
-        ghc = cp.asarray(p['GH'][:,:,ispec,:])
-        mspots = cp.zeros((nwave, ny, nx)) #empty every time!
-        _multispot[numblocks, blocksize](pGHx, pGHy, ghc, mspots)
-        spots[ispec] = mspots
+        spots[ispec] = multispot(pGHx, pGHy, p['GH'][:,:,ispec,:])
 
     #- ensure positivity and normalize
     #- TODO: should this be within multispot itself?
@@ -272,7 +277,9 @@ def get_spots(specmin, nspec, wavelengths, psfdata):
     xc = np.floor(p['X'] - p['HSIZEX'] + 0.5).astype(int)
     yc = np.floor(p['Y'] - p['HSIZEY'] + 0.5).astype(int)
 
-    return spots, (xc, yc)
+    corners = (xc, yc)
+
+    return spots, corners
 
 
 @cuda.jit()

--- a/py/gpu_specter/io.py
+++ b/py/gpu_specter/io.py
@@ -83,14 +83,20 @@ def read_frame(filename):
     Returns a dictionary of numpy arrays
     """
     with fitsio.FITS(filename) as fx:
-        flux = fx['FLUX'].read().astype('f8')
-        ivar = fx['IVAR'].read().astype('f8')
-        wave = fx['WAVELENGTH'].read().astype('f8')
-        resolution = fx['RESOLUTION'].read().astype('f8')
+        flux = fx['FLUX'].read()
+        ivar = fx['IVAR'].read()
+        wave = fx['WAVELENGTH'].read()
+        mask = fx['MASK'].read()
+        resolution = fx['RESOLUTION'].read()
+        fibermap = fx['FIBERMAP'].read()
+        chi2pix = fx['CHI2PIX'].read()
     frame = dict(
         flux=flux,
         ivar=ivar,
         wave=wave,
+        mask=mask,
         resolution=resolution,
+        fibermap=fibermap,
+        chi2pix=chi2pix,
     )
     return frame

--- a/py/gpu_specter/io.py
+++ b/py/gpu_specter/io.py
@@ -86,9 +86,11 @@ def read_frame(filename):
         flux = fx['FLUX'].read().astype('f8')
         ivar = fx['IVAR'].read().astype('f8')
         wave = fx['WAVELENGTH'].read().astype('f8')
+        resolution = fx['RESOLUTION'].read().astype('f8')
     frame = dict(
         flux=flux,
         ivar=ivar,
         wave=wave,
+        resolution=resolution,
     )
     return frame

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -155,10 +155,10 @@ class TestCore(unittest.TestCase):
         diff = frame_cpu['specflux'] - frame_gpu['specflux']
         norm = np.sqrt(1.0/frame_cpu['specivar'] + 1.0/frame_gpu['specivar'])
         pull = diff/norm
-        pull_threshold = 0.01
-        pull_fraction = np.average(np.abs(pull).ravel() < pull_threshold)
-
-        self.assertGreaterEqual(pull_fraction, 0.99)
+        pull_threshold = 1e-4
+        self.assertTrue(np.alltrue(np.abs(pull) < pull_threshold))
+        # pull_fraction = np.average(np.abs(pull) < pull_threshold)
+        # self.assertGreaterEqual(pull_fraction, 0.99)
 
         eps_double = np.finfo(np.float64).eps
         np.testing.assert_allclose(frame_cpu['specflux'], frame_gpu['specflux'], rtol=1e-3, atol=0)

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -120,7 +120,7 @@ class TestCore(unittest.TestCase):
 
         self.assertGreaterEqual(pull_fraction, 0.95)
 
-    @unittest.skipIf(not cupy_available, 'cupy not available')
+    @unittest.skipIf(not gpu_available, 'gpu not available')
     def test_compare_gpu(self):
         bundlesize = 10
         wavelength = '5760.0,7620.0,0.8'

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -162,8 +162,8 @@ class TestCore(unittest.TestCase):
 
         eps_double = np.finfo(np.float64).eps
         np.testing.assert_allclose(frame_cpu['specflux'], frame_gpu['specflux'], rtol=1e-3, atol=0)
-        np.testing.assert_allclose(frame_cpu['specivar'], frame_gpu['specivar'], rtol=1e-4, atol=0)
-        np.testing.assert_allclose(frame_cpu['Rdiags'], frame_gpu['Rdiags'], rtol=1e-3, atol=0)
+        np.testing.assert_allclose(frame_cpu['specivar'], frame_gpu['specivar'], rtol=1e-3, atol=0)
+        np.testing.assert_allclose(frame_cpu['Rdiags'], frame_gpu['Rdiags'], rtol=1e-5, atol=1e-6)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -160,6 +160,10 @@ class TestCore(unittest.TestCase):
 
         self.assertGreaterEqual(pull_fraction, 0.99)
 
+        eps_double = np.finfo(np.float64).eps
+        np.testing.assert_allclose(frame_cpu['specflux'], frame_gpu['specflux'], rtol=1e-3, atol=0)
+        np.testing.assert_allclose(frame_cpu['specivar'], frame_gpu['specivar'], rtol=1e-4, atol=0)
+        np.testing.assert_allclose(frame_cpu['Rdiags'], frame_gpu['Rdiags'], rtol=1e-3, atol=0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -1,0 +1,117 @@
+import unittest, os
+import pkg_resources
+from astropy.table import Table
+import numpy as np
+
+from gpu_specter.io import read_img, read_psf
+from gpu_specter.core import extract_frame
+
+try:
+    import specter.psf
+    import specter.extract
+    specter_available = True
+except ImportError:
+    specter_available = False
+
+try:
+    import cupy as cp
+    from numba import cuda
+    from gpu_specter.extract.gpu import projection_matrix as gpu_projection_matrix
+    gpu_available = cp.is_available()
+except ImportError:
+    gpu_available = False
+
+class TestCore(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.psffile = pkg_resources.resource_filename(
+            'gpu_specter', 'test/data/psf-r0-00051060.fits')
+        cls.psfdata = read_psf(cls.psffile)
+
+        cls.imgfile = pkg_resources.resource_filename(
+            'gpu_specter', 'test/data/preproc-r0-00051060.fits')
+        cls.imgdata = read_img(cls.imgfile)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_extract_frame(self):
+
+        bundlesize = 10
+        wavelength = '6000.0,6100.0,1.0'
+        nwave = 101
+
+        specmin = 0
+        nspec = 10
+        nwavestep = 50
+        nsubbundles = 2
+
+        frame = extract_frame(
+            self.imgdata, self.psfdata, bundlesize,
+            specmin, nspec,
+            wavelength=wavelength,
+            nwavestep=nwavestep, nsubbundles=nsubbundles,
+            comm=None, rank=0, size=1,
+            gpu=None,
+            loglevel='WARN',
+        )
+
+        self.assertEqual(frame['specflux'].shape, (nspec, nwave))
+
+    @unittest.skipIf(not specter_available, 'specter not available')
+    def test_compare_specter(self):
+
+        bundlesize = 10
+        wavelength = '5760.0,7620.0,0.8'
+
+        specmin = 0
+        nspec = 10
+        nwavestep = 50
+        nsubbundles = 2
+
+        frame_spex = extract_frame(
+            self.imgdata, self.psfdata, bundlesize,
+            specmin, nspec,
+            wavelength=wavelength,
+            nwavestep=nwavestep, nsubbundles=nsubbundles,
+            comm=None, rank=0, size=1,
+            gpu=None,
+            loglevel='WARN',
+        )
+
+        self.assertEqual(frame_spex['specflux'].shape[0], nspec)
+
+        psf = specter.psf.load_psf(self.psffile)
+
+        wavelengths = frame_spex['wave']
+
+        frame_specter = specter.extract.ex2d(
+            self.imgdata['image'], self.imgdata['ivar'], psf, 
+            specmin, nspec, wavelengths, 
+            xyrange=None, regularize=0.0, ndecorr=False,
+            bundlesize=bundlesize, nsubbundles=nsubbundles,
+            wavesize=nwavestep, 
+            full_output=True, verbose=False,
+            debug=False, psferr=None,
+        )
+
+        self.assertEqual(frame_spex['specflux'].shape, frame_specter['flux'].shape)
+
+        diff = frame_spex['specflux'] - frame_specter['flux']
+        norm = np.sqrt(1.0/frame_spex['specivar'] + 1.0/frame_specter['ivar'])
+        pull = diff/norm
+        isclose_threshold = 0.01
+        isclose_fraction = np.average(np.abs(pull).ravel() < isclose_threshold)
+
+        self.assertGreaterEqual(isclose_fraction, 0.95)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -21,6 +21,15 @@ try:
 except ImportError:
     gpu_available = False
 
+imgfile = pkg_resources.resource_filename('gpu_specter', 'test/data/preproc-r0-00051060.fits')
+try:
+    img = read_img(imgfile)
+    preproc_available = True
+except:
+    preproc_available = False
+
+
+@unittest.skipIf(not preproc_available, f'{imgfile} not available')
 class TestCore(unittest.TestCase):
 
     @classmethod
@@ -29,9 +38,7 @@ class TestCore(unittest.TestCase):
             'gpu_specter', 'test/data/psf-r0-00051060.fits')
         cls.psfdata = read_psf(cls.psffile)
 
-        cls.imgfile = pkg_resources.resource_filename(
-            'gpu_specter', 'test/data/preproc-r0-00051060.fits')
-        cls.imgdata = read_img(cls.imgfile)
+        cls.imgdata = read_img(imgfile)
 
     @classmethod
     def tearDownClass(cls):

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -140,7 +140,7 @@ class TestCore(unittest.TestCase):
             loglevel='WARN',
         )
 
-        frame_gpu = specter.extract.ex2d(
+        frame_gpu = extract_frame(
             self.imgdata, self.psfdata, bundlesize,
             specmin, nspec,
             wavelength=wavelength,

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -80,7 +80,7 @@ class TestProjectionMatrix(unittest.TestCase):
 
             self.assertEqual(xyrange, xyrange_gpu)
             self.assertEqual(A4.shape, A4_gpu.shape)
-            self.assertTrue(cp.allclose(A4, A4_gpu))
+            self.assertTrue(np.array_equal(A4, cp.asnumpy(A4_gpu)))
 
 
     @unittest.skipIf(not specter_available, 'specter not available')

--- a/py/gpu_specter/test/test_psfcoeff.py
+++ b/py/gpu_specter/test/test_psfcoeff.py
@@ -83,21 +83,25 @@ class TestPSFCoeff(unittest.TestCase):
 
         psfparams_gpu = gpu_evalcoeffs(psfdata, wavelengths)
 
-        self.assertTrue(np.allclose(psfparams['X'], psfparams_gpu['X']))
-        self.assertTrue(np.allclose(psfparams['Y'], psfparams_gpu['Y']))
+        self.assertTrue(np.array_equal(psfparams['X'], cp.asnumpy(psfparams_gpu['X'])))
+        self.assertTrue(np.array_equal(psfparams['Y'], cp.asnumpy(psfparams_gpu['Y'])))
 
         common_keys = set(psfparams.keys() & set(psfparams_gpu.keys()))
         self.assertTrue(len(common_keys) > 0)
 
+        eps_double = np.finfo(np.float64).eps
+
         for key in common_keys:
             # print(f'Comparing {key}')
-            ok = np.allclose(psfparams[key], psfparams_gpu[key])
+            if key == 'GH':
+                continue
+            ok = np.allclose(psfparams[key], cp.asnumpy(psfparams_gpu[key]), rtol=1e2*eps_double, atol=0)
             self.assertTrue(ok, key)
 
         for i in range(psfparams['GH'].shape[0]):
             for j in range(psfparams['GH'].shape[1]):
                 # print(f'Comparing GH-{i}-{j}')
-                ok = np.allclose(psfparams['GH'][i,j], psfparams_gpu['GH'][i,j])
+                ok = np.allclose(psfparams['GH'][i,j], cp.asnumpy(psfparams_gpu['GH'][i,j]), rtol=1e5*eps_double, atol=0)
                 self.assertTrue(ok, f'GH-{i}-{j}')
 
 

--- a/py/gpu_specter/test/test_spots.py
+++ b/py/gpu_specter/test/test_spots.py
@@ -94,11 +94,14 @@ class TestPSFSpots(unittest.TestCase):
             spots_gpu, corners_gpu = gpu_get_spots(ispec, 1, self.wavelengths, self.psfdata)
             xc_gpu, yc_gpu = corners_gpu
 
-            self.assertTrue(cp.allclose(xc, xc_gpu))
-            self.assertTrue(cp.allclose(yc, yc_gpu))
-            self.assertEqual(spots.shape, spots_gpu.shape)
-            self.assertTrue(cp.allclose(spots, spots_gpu))
+            # compare corners
+            self.assertTrue(np.array_equal(xc, cp.asnumpy(xc_gpu)))
+            self.assertTrue(np.array_equal(yc, cp.asnumpy(yc_gpu)))
 
+            # compare spots
+            self.assertEqual(spots.shape, spots_gpu.shape)
+            eps_double = np.finfo(np.float64).eps
+            self.assertTrue(np.allclose(spots, cp.asnumpy(spots_gpu), rtol=eps_double, atol=eps_double))
 
     @unittest.skipIf(not specter_available, 'specter not available')
     def test_compare_specter(self):


### PR DESCRIPTION
This PR adds a unit test that compares the output of `gpu_specter.core.extract_frame` and `specter.extract.ex2d` using a small fraction of a full input image/psf. The unit test checks that the 95% of the values in the pull distribution are less than `0.01`:

```
pull = abs(f1 - f2) / sqrt(var1 + var2)
assert average(pull < 0.01) >= 0.95
```

The PR also adds a helper script for comparing spex and specter that is a bit more flexible than the hardcoded unittest. I also updated the testing doc.

Potential issues:
 * The unittest is a bit slow.
 * Need to manually copy the right image file into `py/gpu_specter/test/data/`