### PR TITLE
Implement model and regularize command line options

### DIFF
--- a/bin/spex
+++ b/bin/spex
@@ -32,8 +32,8 @@ def parse(options=None):
                         help="first spectrum to extract")
     parser.add_argument("-n", "--nspec", type=int, required=False, default=500,
                         help="number of spectra to extract")
-    # parser.add_argument("-r", "--regularize", type=float, required=False, default=0.0,
-    #                     help="regularization amount (default %(default)s)")
+    parser.add_argument("-r", "--regularize", type=float, required=False, default=0.0,
+                        help="regularization amount (default %(default)s)")
     parser.add_argument("--bundlesize", type=int, required=False, default=25,
                         help="number of spectra per bundle")
     parser.add_argument("--nsubbundles", type=int, required=False, default=5,
@@ -146,6 +146,7 @@ def main(args=None):
         args.wavelength,                   # wavelength range to extract
         args.nwavestep, args.nsubbundles,  # extraction algorithm parameters
         args.model,
+        args.regularize,
         comm, rank, size,                  # mpi parameters
         args.gpu,                          # gpu parameters
         args.loglevel,                     # log

--- a/bin/spex
+++ b/bin/spex
@@ -10,7 +10,7 @@ from pkg_resources import resource_filename
 import numpy as np
 
 from gpu_specter.util import get_logger, Timer
-from gpu_specter.io import read_img, read_psf, write_frame
+from gpu_specter.io import read_img, read_psf, write_frame, write_model
 from gpu_specter.core import extract_frame
 
 def parse(options=None):
@@ -24,8 +24,8 @@ def parse(options=None):
                         help="input psf file")
     parser.add_argument("-o", "--output", type=str, required=True,
                         help="output extracted spectra file")
-    # parser.add_argument("-m", "--model", type=str, required=False,
-    #                     help="output 2D pixel model file")
+    parser.add_argument("-m", "--model", type=str, required=False,
+                        help="output 2D pixel model file")
     parser.add_argument("-w", "--wavelength", type=str, required=False,
                         help="wavemin,wavemax,dw")
     parser.add_argument("-s", "--specmin", type=int, required=False, default=0,
@@ -145,6 +145,7 @@ def main(args=None):
         args.specmin, args.nspec,          # spectra to extract (specmin, specmin + nspec)
         args.wavelength,                   # wavelength range to extract
         args.nwavestep, args.nsubbundles,  # extraction algorithm parameters
+        args.model,
         comm, rank, size,                  # mpi parameters
         args.gpu,                          # gpu parameters
         args.loglevel,                     # log
@@ -157,6 +158,10 @@ def main(args=None):
         if args.output is not None:
             log.info(f'Writing {args.output}')
             write_frame(args.output, frame)
+
+        if args.model is not None:
+            log.info(f'Writing model {args.model}')
+            write_model(args.model, frame)
 
     #- Print timing summary
     if rank == 0:

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -110,8 +110,8 @@ def assemble_bundle_patches(rankresults):
         xstart = min(xstart, patch.xyslice[1].start)
         xstop = max(xstop, patch.xyslice[1].stop)
     ny, nx = ystop - ystart, xstop - xstart
-    xyslice= xp.s_[ystart:ystop, xstart:xstop]
-    model = xp.zeros((ny, nx))
+    xyslice = np.s_[ystart:ystop, xstart:xstop]
+    modelimage = xp.zeros((ny, nx))
 
     #- Now put these into the final arrays
     for patch, result in allresults:
@@ -129,14 +129,14 @@ def assemble_bundle_patches(rankresults):
         Rdiags[patch.specslice, :, patch.waveslice] = xRdiags[:, :, patch.keepslice]
 
         patchmodel = result['modelimage']
-        if patchmodel is None:
+        if patchmodel is None or ~np.all(np.isfinite(patchmodel)):
             continue
         ymin = patch.xyslice[0].start - ystart
         xmin = patch.xyslice[1].start - xstart
         patchny, patchnx = patchmodel.shape
-        model[ymin:ymin+patchny, xmin:xmin+patchnx] += patchmodel
+        modelimage[ymin:ymin+patchny, xmin:xmin+patchnx] += patchmodel
 
-    return specflux, specivar, Rdiags, model, xyslice
+    return specflux, specivar, Rdiags, modelimage, xyslice
 
 
 def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=25, nsubbundles=1,
@@ -253,13 +253,13 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             flux = []
             fluxivar = []
             resolution = []
-            model = []
+            mimage = []
             for patch, results in results:
                 patches.append(patch)
                 flux.append(results['flux'])
                 fluxivar.append(results['ivar'])
                 resolution.append(results['Rdiags'])
-                model.append(results['model'])
+                mimage.append(cp.asnumpy(results['modelimage']))
 
             # transfer to host in 3 chunks
             cp.cuda.nvtx.RangePush('copy bundle results to host')
@@ -268,7 +268,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             flux = cp.asnumpy(cp.array(flux, dtype=cp.float64))
             fluxivar = cp.asnumpy(cp.array(fluxivar, dtype=cp.float64))
             resolution = cp.asnumpy(cp.array(resolution, dtype=cp.float64))
-            model = cp.asnumpy(cp.array(model, dtype=np.float64))
+            # mimage = cp.asnumpy(cp.array(mimage, dtype=np.float64))
             cp.cuda.nvtx.RangePop()
 
             # gather to root MPI rank
@@ -276,16 +276,19 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             flux = gather_ndarray(flux, comm, root=0)
             fluxivar = gather_ndarray(fluxivar, comm, root=0)
             resolution = gather_ndarray(resolution, comm, root=0)
-            model = gather_ndarray(model, comm, root=0)
+            # mimage = gather_ndarray(mimage, comm, root=0)
+            mimage = comm.gather(mimage, root=0)
 
             if rank == 0:
                 # unpack patches
                 patches = [patch for rankpatches in patches for patch in rankpatches]
+                mimage = [m for rankm in mimage for m in rankm]
+
                 # repack everything
                 rankresults = [
                     zip(patches,
-                        map(lambda x: dict(flux=x[0], ivar=x[1], Rdiags=x[2], model=x[3]),
-                            zip(flux, fluxivar, resolution, model)
+                        map(lambda x: dict(flux=x[0], ivar=x[1], Rdiags=x[2], modelimage=x[3]),
+                            zip(flux, fluxivar, resolution, mimage)
                         )
                     )
                 ]
@@ -310,7 +313,15 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                 cp.cuda.nvtx.RangePush('copy bundle results to host')
                 device_id = cp.cuda.runtime.getDevice()
                 log.info(f'Rank {rank}: Moving bundle {bspecmin} to host from device {device_id}')
-                bundle = tuple(cp.asnumpy(x) for x in bundle)
+                specflux, specivar, Rdiags, modelimage, xyslice = bundle
+                bundle = (
+                    cp.asnumpy(specflux),
+                    cp.asnumpy(specivar),
+                    cp.asnumpy(Rdiags),
+                    cp.asnumpy(modelimage),
+                    xyslice
+                )
+                # bundle = tuple(cp.asnumpy(x) for x in bundle)
                 cp.cuda.nvtx.RangePop()
         timer.split('assembled patches')
         timer.log_splits(log)
@@ -477,10 +488,12 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             flux = gather_ndarray(flux, frame_comm)
             ivar = gather_ndarray(ivar, frame_comm)
             resolution = gather_ndarray(resolution, frame_comm)
-            modelimage = gather_ndarray(modelimage, frame_comm, root=0)
+            modelimage = frame_comm.gather(modelimage, root=0)
             if rank == 0:
                 bspecmin = [bspecmin for rankbspecmins in bspecmins for bspecmin in rankbspecmins]
-                rankbundles = [list(zip(bspecmin, zip(flux, ivar, resolution, modelimage, xyslice))), ]
+                mimage = [m for rankmodelimage in modelimage for m in rankmodelimage]
+                mxy = [xy for rankxyslice in xyslice for xy in rankxyslice]
+                rankbundles = [list(zip(bspecmin, zip(flux, ivar, resolution, mimage, mxy))), ]
     else:
         # no mpi or single group with all ranks
         rankbundles = [bundles,]
@@ -503,11 +516,11 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
         Rdiags = np.vstack([b[1][2] for b in allbundles])
 
         if model:
-            modelimage = np.zeros_like(imgpixels)
+            modelimage = np.zeros(imgpixels.shape)
             for b in allbundles:
-                model = b[1][3]
+                bundleimage = b[1][3]
                 xyslice = b[1][4]
-                modelimage[xyslice] += model
+                modelimage[xyslice] += bundleimage
         else:
             modelimage = None
 

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -364,6 +364,7 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
         import cupy as cp
         #- TODO: specify number of gpus to use?
         device_count = cp.cuda.runtime.getDeviceCount()
+        device_count = min(size, device_count)
         assert size % device_count == 0, 'Number of MPI ranks must be divisible by number of GPUs'
         device_id = rank % device_count
         cp.cuda.Device(device_id).use()

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -140,7 +140,7 @@ def assemble_bundle_patches(rankresults):
 
 
 def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=25, nsubbundles=1,
-    nwavestep=50, wavepad=10, comm=None, gpu=None, loglevel=None, model=None):
+    nwavestep=50, wavepad=10, comm=None, gpu=None, loglevel=None, model=None, regularize=0):
     """
     Extract 1D spectra from a single bundle of a 2D image.
 
@@ -236,7 +236,8 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                              spots, corners,
                              wavepad=patch.wavepad,
                              bundlesize=bundlesize,
-                             model=model)
+                             model=model,
+                             regularize=regularize)
         patch.xyslice = result['xyslice']
         if gpu:
             cp.cuda.nvtx.RangePop()
@@ -329,7 +330,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
 
 
 def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavestep=50, nsubbundles=1,
-    model=None, comm=None, rank=0, size=1, gpu=None, loglevel=None):
+    model=None, regularize=0, comm=None, rank=0, size=1, gpu=None, loglevel=None):
     """
     Extract 1D spectra from 2D image.
 
@@ -467,6 +468,7 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             gpu=gpu,
             loglevel=loglevel,
             model=model,
+            regularize=regularize,
         )
         if gpu:
             cp.cuda.nvtx.RangePop()

--- a/py/gpu_specter/extract/both.py
+++ b/py/gpu_specter/extract/both.py
@@ -45,12 +45,12 @@ def xp_deconvolve(pixel_values, pixel_ivar, A, regularize=0, debug=False):
     iCov, y, fluxweight = xp_dotall(pixel_values, pixel_ivar, A)
     #- Add a weak flux=0 prior to avoid singular matrices
     #- TODO: review this; compare to specter
-    Idiag = regularize*xp.ones_like(y)
     minweight = 1e-4*xp.max(fluxweight)
     ibad = fluxweight < minweight
-    Idiag[ibad] = minweight - fluxweight[ibad]
-    if xp.any(Idiag):
-        iCov += xp.diag(Idiag*Idiag)
+    lambda_squared = regularize*regularize*xp.ones_like(y)
+    lambda_squared[ibad] = minweight - fluxweight[ibad]
+    if xp.any(lambda_squared):
+        iCov += xp.diag(lambda_squared)
     safe_range_pop(xp)
 
     #- Solve the linear least-squares problem.

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -523,12 +523,12 @@ def deconvolve(pixel_values, pixel_ivar, A, regularize=0, debug=False):
     iCov, y, fluxweight = dotall(pixel_values, pixel_ivar, A)
     #- Add a weak flux=0 prior to avoid singular matrices
     #- TODO: review this; compare to specter
-    Idiag = regularize*np.ones_like(y)
     minweight = 1e-4*np.max(fluxweight)
     ibad = fluxweight < minweight
-    Idiag[ibad] = minweight - fluxweight[ibad]
-    if np.any(Idiag):
-        iCov += np.diag(Idiag*Idiag)
+    lambda_squared = regularize*regularize*np.ones_like(y)
+    lambda_squared[ibad] = minweight - fluxweight[ibad]
+    if np.any(lambda_squared):
+        iCov += np.diag(lambda_squared)
     #- Solve the linear least-squares problem.
     deconvolved = scipy.linalg.solve(iCov, y)
     return deconvolved, iCov

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -412,7 +412,8 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
         xyslice = None
 
     if model:
-        A = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave].reshape(ny*nx, nspec*nwave)
+        A4slice = np.s_[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave]
+        A = A4[A4slice].reshape(ny*nx, nspec*nwave)
         modelimage = A.dot(specflux.ravel()).reshape(ny, nx)
     else:
         modelimage = None

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -344,7 +344,7 @@ def get_resolution_diags(R, ndiag, ispec, nspec, nwave, wavepad):
     return Rdiags
 
 def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
-                wavepad, bundlesize=25):
+                wavepad, bundlesize=25, model=None):
     """
     Extracted a patch with border padding, but only return results for patch
 
@@ -409,12 +409,21 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
         specflux = np.zeros((nspec, nwave))
         specivar = np.zeros((nspec, nwave))
         Rdiags = np.zeros( (nspec, 2*ndiag+1, nwave) )
+        xyslice = None
+
+    if model:
+        A = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave].reshape(ny*nx, nspec*nwave)
+        modelimage = A.dot(specflux.ravel()).reshape(ny, nx)
+    else:
+        modelimage = None
 
     #- TODO: add chi2pix, pixmask_fraction, optionally modelimage; see specter
     result = dict(
         flux = specflux,
         ivar = specivar,
         Rdiags = Rdiags,
+        modelimage = modelimage,
+        xyslice = xyslice,
     )
 
     return result

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -344,7 +344,7 @@ def get_resolution_diags(R, ndiag, ispec, nspec, nwave, wavepad):
     return Rdiags
 
 def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
-                wavepad, bundlesize=25, model=None):
+                wavepad, bundlesize=25, model=None, regularize=0):
     """
     Extracted a patch with border padding, but only return results for patch
 
@@ -393,7 +393,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
 
     if (0 <= ymin) & (ymin+ny < image.shape[0]):
         xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
-        fx, ivarfx, R = ex2d_patch(image[xyslice], imageivar[xyslice], A4)
+        fx, ivarfx, R = ex2d_patch(image[xyslice], imageivar[xyslice], A4, regularize=regularize)
 
         #- Select the non-padded spectra x wavelength core region
         specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
@@ -468,7 +468,44 @@ def dotdot3(A, w):
 
     return B
 
-def deconvolve(pixel_values, pixel_ivar, A, debug=False):
+@numba.jit(nopython=True)
+def dotall(p, w, A):
+    '''Compute icov, y and fluxweight in the same loop(s)
+
+        icov = A^T W A
+        y = A^T W p
+        fluxweight = (A^T W).sum(axis=1)
+
+    Arguments:
+        pixel_values: pixel values
+        pixel_ivar: pixel weights
+        A: projection matrix
+
+    Returns:
+        icov, y, fluxweight
+    '''
+    n, m = A.shape
+    icov = np.zeros((m,m))
+    y = np.zeros(m)
+    fluxweight = np.zeros(m)
+    for i in range(n):
+        for j1 in range(m):
+            Aw = w[i] * A[i,j1]
+            if Aw != 0.0:
+                for j2 in range(j1, m):
+                    tmp = Aw * A[i,j2]
+                    icov[j1, j2] += tmp
+                fluxweight[j1] += Aw
+                y[j1] += Aw * p[i]
+
+    #- fill in other half
+    for j1 in range(m-1):
+        for j2 in range(j1+1, m):
+            icov[j2, j1] = icov[j1, j2]
+
+    return icov, y, fluxweight
+
+def deconvolve(pixel_values, pixel_ivar, A, regularize=0, debug=False):
     """Calculate the weighted linear least-squares flux solution for an observed trace.
 
     Args:
@@ -482,11 +519,15 @@ def deconvolve(pixel_values, pixel_ivar, A, debug=False):
 
     """
     #- Set up the equation to solve (B&S eq 4)
-    iCov = dotdot3(A, pixel_ivar)
-    y = (A.T * pixel_ivar).dot(pixel_values)
+    iCov, y, fluxweight = dotall(pixel_values, pixel_ivar, A)
     #- Add a weak flux=0 prior to avoid singular matrices
     #- TODO: review this; compare to specter
-    iCov += 1e-12*np.eye(iCov.shape[0])
+    Idiag = regularize*np.ones_like(y)
+    minweight = 1e-4*np.max(fluxweight)
+    ibad = fluxweight < minweight
+    Idiag[ibad] = minweight - fluxweight[ibad]
+    if np.any(Idiag):
+        iCov += np.diag(Idiag*Idiag)
     #- Solve the linear least-squares problem.
     deconvolved = scipy.linalg.solve(iCov, y)
     return deconvolved, iCov
@@ -558,7 +599,7 @@ def decorrelate_blocks(iCov, block_size, debug=False):
     return ivar, R
 
 # @profile
-def ex2d_patch(noisyimg, imgweights, A4, decorrelate='signal', debug=False):
+def ex2d_patch(noisyimg, imgweights, A4, decorrelate='signal', regularize=0, debug=False):
     '''
     Perform spectroperfectionism extractions returning flux, varflux, R
 
@@ -581,7 +622,7 @@ def ex2d_patch(noisyimg, imgweights, A4, decorrelate='signal', debug=False):
     A = A4.reshape(ny*nx, nspec*nwave)
 
     #- Solve f (B&S eq 4)
-    deconvolved, iCov = deconvolve(noisyimg.ravel(), imgweights.ravel(), A)
+    deconvolved, iCov = deconvolve(noisyimg.ravel(), imgweights.ravel(), A, regularize=regularize)
 
     #- Calculate the decorrelated errors and resolution matrix.
     if decorrelate == 'signal':

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -478,7 +478,8 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
         xyslice = None
 
     if model:
-        A = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave].reshape(ny*nx, nspec*nwave)
+        A4slice = np.s_[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave]
+        A = A4[A4slice].reshape(ny*nx, nspec*nwave)
         modelimage = A.dot(specflux.ravel()).reshape(ny, nx)
     else:
         modelimage = cp.zeros((ny, nx))

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -481,7 +481,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
         A = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave].reshape(ny*nx, nspec*nwave)
         modelimage = A.dot(specflux.ravel()).reshape(ny, nx)
     else:
-        modelimage = None
+        modelimage = cp.zeros((ny, nx))
 
     #- TODO: add chi2pix, pixmask_fraction, optionally modelimage; see specter
     cp.cuda.nvtx.RangePush('prepare result')

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -385,7 +385,7 @@ def get_resolution_diags(R, ndiag, ispec, nspec, nwave, wavepad):
     return Rdiags
 
 def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
-                wavepad, bundlesize=25, model=None):
+                wavepad, bundlesize=25, model=None, regularize=0):
     """
     Extracted a patch with border padding, but only return results for patch
 
@@ -449,7 +449,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners,
         xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
         # timer.split('ready for extraction')
         cp.cuda.nvtx.RangePush('extract patch')
-        fx, ivarfx, R = xp_ex2d_patch(image[xyslice], imageivar[xyslice], A4)
+        fx, ivarfx, R = xp_ex2d_patch(image[xyslice], imageivar[xyslice], A4, regularize=regularize)
         cp.cuda.nvtx.RangePop()
         # timer.split('extracted patch')
 

--- a/py/gpu_specter/io.py
+++ b/py/gpu_specter/io.py
@@ -76,6 +76,13 @@ def write_frame(filename, frame, dtype=np.float32):
         fx.write(frame['chi2pix'].astype(dtype), extname='CHI2PIX')
     os.rename(tmpfilename, filename)
 
+def write_model(filename, frame):
+    """Write image model to output filename"""
+    tmpfilename = filename + '.tmp'
+    with fitsio.FITS(tmpfilename, 'rw', clobber=True) as fx:
+        fx.write(frame['modelimage'], extname='MODEL', header=frame['imagehdr'])
+    os.rename(tmpfilename, filename)
+
 def read_frame(filename):
     """
     Read frame data (extracted 1D spectra) from input filename

--- a/py/gpu_specter/test/test_extract.py
+++ b/py/gpu_specter/test/test_extract.py
@@ -6,7 +6,6 @@ import numpy as np
 from gpu_specter.io import read_psf
 from gpu_specter.extract.cpu import projection_matrix, get_spots, ex2d_patch, get_resolution_diags
 from gpu_specter.extract.both import xp_ex2d_patch
-from gpu_specter.extract.gpu import get_resolution_diags as gpu_get_resolution_diags
 
 try:
     import specter.psf

--- a/py/gpu_specter/test/test_extract.py
+++ b/py/gpu_specter/test/test_extract.py
@@ -185,6 +185,8 @@ class TestEx2dPatch(unittest.TestCase):
 
     @unittest.skipIf(not cupy_available, 'cupy not available')
     def test_compare_get_Rdiags(self):
+        from gpu_specter.extract.gpu import get_resolution_diags as gpu_get_resolution_diags
+
         nspec, ispec, specmin = 5, 5, 4
         nwave, wavepad, ndiag = 50, 10, 7
         nwavetot = nwave + 2*wavepad


### PR DESCRIPTION
This PR implements support for the `--model` and `--regularize` command line options in spex/gpu_specter. 

The model image is computed at the patch level which is another piece of data that has to be passed through the appropriate frame and bundle MPI communicators. It's becoming a bit unwieldy but fixing that might be an issue for a separate PR.

The regularization is modeled after the implementation in specter but modifies the diagonal elements of icov rather than appending to the design matrix which is used to compute icov. This avoids what would be a noticeable performance hit with `np.vstack( (A, Idiag) )` as done in specter.

All cpu/specter tests are passing using the desi environment on a haswell node.
All cpu/gpu tests are passing using the desi-gpu environment on a cori gpu node.