### PR TITLE
Implement chi2pix and pixmask_fraction calculation

### DIFF
--- a/bin/spex
+++ b/bin/spex
@@ -158,6 +158,9 @@ def main(args=None):
     #- Write output
     if rank == 0:
         if args.output is not None:
+            frame['imagehdr'] = img['imagehdr']
+            frame['fibermap'] = img['fibermap']
+            frame['fibermaphdr'] = img['fibermaphdr']
             log.info(f'Writing {args.output}')
             write_frame(args.output, frame)
 

--- a/bin/spex
+++ b/bin/spex
@@ -46,8 +46,8 @@ def parse(options=None):
     parser.add_argument("--gpu", action="store_true", help="Use GPU for extraction")
     # parser.add_argument("--decorrelate-fibers", action="store_true", help="Not recommended")
     # parser.add_argument("--no-scores", action="store_true", help="Do not compute scores")
-    # parser.add_argument("--psferr", type=float, default=None, required=False,
-    #                     help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
+    parser.add_argument("--psferr", type=float, default=None, required=False,
+                        help="fractional PSF model error used to compute chi2 and mask pixels (default = value saved in psf file)")
     # parser.add_argument("--fibermap-index", type=int, default=None, required=False,
     #                     help="start at this index in the fibermap table instead of using the spectro id from the camera")
     # parser.add_argument("--barycentric-correction", action="store_true", help="apply barycentric correction to wavelength")
@@ -147,6 +147,7 @@ def main(args=None):
         args.nwavestep, args.nsubbundles,  # extraction algorithm parameters
         args.model,
         args.regularize,
+        args.psferr,
         comm, rank, size,                  # mpi parameters
         args.gpu,                          # gpu parameters
         args.loglevel,                     # log

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -510,18 +510,20 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
         # gather results from multiple mpi groups
         if bundle_rank == 0:
             bspecmins, bundles = zip(*bundles)
-            flux, ivar, resolution, modelimage, xyslice = zip(*bundles)
+            flux, ivar, resolution, pixmask_fraction, chi2pix, modelimage, xyslice = zip(*bundles)
             bspecmins = frame_comm.gather(bspecmins, root=0)
             xyslice = frame_comm.gather(xyslice, root=0)
             flux = gather_ndarray(flux, frame_comm)
             ivar = gather_ndarray(ivar, frame_comm)
             resolution = gather_ndarray(resolution, frame_comm)
+            pixmask_fraction = gather_ndarray(pixmask_fraction, frame_comm)
+            chi2pix = gather_ndarray(chi2pix, frame_comm)
             modelimage = frame_comm.gather(modelimage, root=0)
             if rank == 0:
                 bspecmin = [bspecmin for rankbspecmins in bspecmins for bspecmin in rankbspecmins]
                 modelimage = [m for _ in modelimage for m in _]
                 mxy = [xy for rankxyslice in xyslice for xy in rankxyslice]
-                rankbundles = [list(zip(bspecmin, zip(flux, ivar, resolution, modelimage, mxy))), ]
+                rankbundles = [list(zip(bspecmin, zip(flux, ivar, resolution, pixmask_fraction, chi2pix, modelimage, mxy))), ]
     else:
         # no mpi or single group with all ranks
         rankbundles = [bundles,]

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -98,6 +98,8 @@ def assemble_bundle_patches(rankresults):
     specflux = xp.zeros((bundlesize, nwave))
     specivar = xp.zeros((bundlesize, nwave))
     Rdiags = xp.zeros((bundlesize, 2*ndiag+1, nwave))
+    pixmask_fraction = xp.zeros((bundlesize, nwave))
+    chi2pix = xp.zeros((bundlesize, nwave))
 
     #- Find the global extent of patches in this bundle
     ystart = xstart = float('inf')
@@ -118,6 +120,8 @@ def assemble_bundle_patches(rankresults):
         fx = result['flux']
         fxivar = result['ivar']
         xRdiags = result['Rdiags']
+        xpixmask_fraction = result['pixmask_fraction']
+        xchi2pix = result['chi2pix']
 
         if patch.xyslice is None:
             # print(f'patch {(patch.ispec, patch.iwave)} is off the edge of the image')
@@ -127,6 +131,8 @@ def assemble_bundle_patches(rankresults):
         specflux[patch.specslice, patch.waveslice] = fx[:, patch.keepslice]
         specivar[patch.specslice, patch.waveslice] = fxivar[:, patch.keepslice]
         Rdiags[patch.specslice, :, patch.waveslice] = xRdiags[:, :, patch.keepslice]
+        pixmask_fraction[patch.specslice, patch.waveslice] = xpixmask_fraction[:, patch.keepslice]
+        chi2pix[patch.specslice, patch.waveslice] = xchi2pix[:, patch.keepslice]
 
         patchmodel = result['modelimage']
         if patchmodel is None or ~np.all(np.isfinite(patchmodel)):
@@ -136,11 +142,12 @@ def assemble_bundle_patches(rankresults):
         patchny, patchnx = patchmodel.shape
         modelimage[ymin:ymin+patchny, xmin:xmin+patchnx] += patchmodel
 
-    return specflux, specivar, Rdiags, modelimage, xyslice
+    return specflux, specivar, Rdiags, pixmask_fraction, chi2pix, modelimage, xyslice
 
 
 def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=25, nsubbundles=1,
-    nwavestep=50, wavepad=10, comm=None, gpu=None, loglevel=None, model=None, regularize=0):
+    nwavestep=50, wavepad=10, comm=None, gpu=None, loglevel=None, model=None, regularize=0,
+    psferr=None):
     """
     Extract 1D spectra from a single bundle of a 2D image.
 
@@ -197,6 +204,8 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
     spots, corners = get_spots(bspecmin, bundlesize, fullwave, psf)
     if gpu:
         cp.cuda.nvtx.RangePop()
+    if psferr is None:
+        psferr = psf['PSF'].meta['PSFERR']
 
     timer.split('spots/corners')
 
@@ -233,11 +242,12 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
         result = ex2d_padded(image, imageivar,
                              patch.ispec-bspecmin, patch.nspectra_per_patch,
                              patch.iwave, patch.nwavestep,
-                             spots, corners,
+                             spots, corners, psferr,
                              wavepad=patch.wavepad,
                              bundlesize=bundlesize,
                              model=model,
-                             regularize=regularize)
+                             regularize=regularize,
+                             )
         patch.xyslice = result['xyslice']
         if gpu:
             cp.cuda.nvtx.RangePop()
@@ -254,21 +264,27 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             flux = []
             fluxivar = []
             resolution = []
+            pixmask_fraction = []
+            chi2pix = []
             modelimage = []
             for patch, results in results:
                 patches.append(patch)
                 flux.append(results['flux'])
                 fluxivar.append(results['ivar'])
                 resolution.append(results['Rdiags'])
+                pixmask_fraction.append(results['pixmask_fraction'])
+                chi2pix.append(results['chi2pix'])
                 modelimage.append(cp.asnumpy(results['modelimage']))
 
-            # transfer to host in 3 chunks
+            # transfer to host in chunks
             cp.cuda.nvtx.RangePush('copy bundle results to host')
             device_id = cp.cuda.runtime.getDevice()
             log.info(f'Rank {rank}: Moving bundle {bspecmin} patches to host from device {device_id}')
             flux = cp.asnumpy(cp.array(flux, dtype=cp.float64))
             fluxivar = cp.asnumpy(cp.array(fluxivar, dtype=cp.float64))
             resolution = cp.asnumpy(cp.array(resolution, dtype=cp.float64))
+            pixmask_fraction = cp.asnumpy(cp.array(pixmask_fraction, dtype=cp.float64))
+            chi2pix = cp.asnumpy(cp.array(chi2pix, dtype=cp.float64))
             cp.cuda.nvtx.RangePop()
 
             # gather to root MPI rank
@@ -276,6 +292,8 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             flux = gather_ndarray(flux, comm, root=0)
             fluxivar = gather_ndarray(fluxivar, comm, root=0)
             resolution = gather_ndarray(resolution, comm, root=0)
+            pixmask_fraction = gather_ndarray(pixmask_fraction, comm, root=0)
+            chi2pix = gather_ndarray(chi2pix, comm, root=0)
             modelimage = comm.gather(modelimage, root=0)
 
             if rank == 0:
@@ -286,8 +304,14 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                 # repack everything
                 rankresults = [
                     zip(patches,
-                        map(lambda x: dict(flux=x[0], ivar=x[1], Rdiags=x[2], modelimage=x[3]),
-                            zip(flux, fluxivar, resolution, modelimage)
+                        map(lambda x: dict(
+                                flux=x[0], ivar=x[1], Rdiags=x[2],
+                                pixmask_fraction=x[3], chi2pix=x[4], modelimage=x[3]
+                            ),
+                            zip(
+                                flux, fluxivar, resolution, 
+                                pixmask_fraction, chi2pix, modelimage
+                            )
                         )
                     )
                 ]
@@ -312,11 +336,13 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                 cp.cuda.nvtx.RangePush('copy bundle results to host')
                 device_id = cp.cuda.runtime.getDevice()
                 log.info(f'Rank {rank}: Moving bundle {bspecmin} to host from device {device_id}')
-                specflux, specivar, Rdiags, modelimage, xyslice = bundle
+                specflux, specivar, Rdiags, pixmask_fraction, chi2pix, modelimage, xyslice = bundle
                 bundle = (
                     cp.asnumpy(specflux),
                     cp.asnumpy(specivar),
                     cp.asnumpy(Rdiags),
+                    cp.asnumpy(pixmask_fraction),
+                    cp.asnumpy(chi2pix),
                     cp.asnumpy(modelimage),
                     xyslice
                 )
@@ -328,7 +354,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
 
 
 def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavestep=50, nsubbundles=1,
-    model=None, regularize=0, comm=None, rank=0, size=1, gpu=None, loglevel=None):
+    model=None, regularize=0, psferr=None, comm=None, rank=0, size=1, gpu=None, loglevel=None):
     """
     Extract 1D spectra from 2D image.
 
@@ -468,6 +494,7 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             loglevel=loglevel,
             model=model,
             regularize=regularize,
+            psferr=psferr,
         )
         if gpu:
             cp.cuda.nvtx.RangePop()
@@ -515,12 +542,14 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
         specflux = np.vstack([b[1][0] for b in allbundles])
         specivar = np.vstack([b[1][1] for b in allbundles])
         Rdiags = np.vstack([b[1][2] for b in allbundles])
+        pixmask_fraction = np.vstack([b[1][3] for b in allbundles])
+        chi2pix = np.vstack([b[1][4] for b in allbundles])
 
         if model:
             modelimage = np.zeros(imgpixels.shape)
             for b in allbundles:
-                bundleimage = b[1][3]
-                xyslice = b[1][4]
+                bundleimage = b[1][5]
+                xyslice = b[1][6]
                 modelimage[xyslice] += bundleimage
         else:
             modelimage = None
@@ -533,8 +562,11 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
         specivar *= dwave**2
 
         #- TODO: specmask and chi2pix
+        # mask = np.zeros(flux.shape, dtype=np.uint32)
+        # mask[results['pixmask_fraction']>0.5] |= specmask.SOMEBADPIX
+        # mask[results['pixmask_fraction']==1.0] |= specmask.ALLBADPIX
+        # mask[chi2pix>100.0] |= specmask.BAD2DFIT
         specmask = (specivar == 0).astype(np.int)
-        chi2pix = np.ones(specflux.shape)
 
         frame = dict(
             specflux = specflux,
@@ -542,7 +574,8 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             specmask = specmask,
             wave = wave,
             Rdiags = Rdiags,
-            chi2pix = np.ones(specflux.shape),
+            pixmask_fraction = pixmask_fraction,
+            chi2pix = chi2pix,
             imagehdr = img['imagehdr'],
             fibermap = img['fibermap'],
             fibermaphdr =  img['fibermaphdr'],

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -576,9 +576,6 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             Rdiags = Rdiags,
             pixmask_fraction = pixmask_fraction,
             chi2pix = chi2pix,
-            imagehdr = img['imagehdr'],
-            fibermap = img['fibermap'],
-            fibermaphdr =  img['fibermaphdr'],
             modelimage = modelimage,
         )
 

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -411,7 +411,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, ps
         Rdiags = np.zeros( (nspec, 2*ndiag+1, nwave) )
         xyslice = None
 
-    if np.any(np.isnan(fx)):
+    if np.any(np.isnan(specflux)):
         raise RuntimeError('Found NaN in extracted flux')
 
     Apadded = A4.reshape(ny*nx, nspecpad*nwavetot)

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -391,12 +391,12 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, ps
     #- Diagonals of R in a form suited for creating scipy.sparse.dia_matrix
     ndiag = spots.shape[2]//2
 
+    specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
     if (0 <= ymin) & (ymin+ny < image.shape[0]):
         xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
         fx, ivarfx, R = ex2d_patch(image[xyslice], imageivar[xyslice], A4, regularize=regularize)
 
         #- Select the non-padded spectra x wavelength core region
-        specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
         specflux = fx[specslice]
         specivar = ivarfx[specslice]
 
@@ -411,6 +411,9 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, ps
         Rdiags = np.zeros( (nspec, 2*ndiag+1, nwave) )
         xyslice = None
 
+    if np.any(np.isnan(fx)):
+        raise RuntimeError('Found NaN in extracted flux')
+
     Apadded = A4.reshape(ny*nx, nspecpad*nwavetot)
     Apatch = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave]
     Apatch = Apatch.reshape(ny*nx, nspec*nwave)
@@ -423,13 +426,16 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, ps
     ii = (modelivar > 0 ) & (imageivar[xyslice] > 0)
     totpix_ivar = np.zeros((ny, nx))
     totpix_ivar[ii] = 1.0 / (1.0/modelivar[ii] + 1.0/imageivar[xyslice][ii])
+
+    #- Weighted chi2 of pixels that contribute to each flux bin;
+    #- only use unmasked pixels and avoid dividing by 0
     chi = (image[xyslice] - modelpadded)*np.sqrt(totpix_ivar)
-    psfweight = Apatch.T.dot(totpix_ivar.ravel() > 0)
+    psfweight = Apadded.T.dot(totpix_ivar.ravel() > 0)
     bad = psfweight == 0
 
     #- Compute chi2pix and reshape
-    chi2pix = (Apatch.T.dot(chi.ravel()**2) * ~bad) / (psfweight + bad)
-    chi2pix = chi2pix.reshape(nspec, nwave)
+    chi2pix = (Apadded.T.dot(chi.ravel()**2) * ~bad) / (psfweight + bad)
+    chi2pix = chi2pix.reshape(nspecpad, nwavetot)[specslice]
 
     if model:
         modelimage = Apatch.dot(specflux.ravel()).reshape(ny, nx)
@@ -598,6 +604,16 @@ def decorrelate_blocks(iCov, block_size, debug=False):
     assert not debug or np.all(u > 0), 'Found some negative iCov eigenvalues.'
     # Check that the eigenvectors are orthonormal so that vt.v = 1
     assert not debug or np.allclose(np.eye(len(u)), v.T.dot(v))
+
+    if debug:
+        threshold = 10.0 * sys.float_info.epsilon
+        maxval = np.max(u)
+        minval = maxval * threshold
+        i = u > minval
+        if np.any(~i):
+            raise RuntimeError(f'Eigenvalue below minval {minval}: {u[i]}')
+        # u = np.clip(u, minval, None)
+
     C = (v * (1.0/u)).dot(v.T)
     #- Calculate C^-1 = QQ (B&S eq 17-19)
     Q = np.zeros_like(iCov)
@@ -609,6 +625,16 @@ def decorrelate_blocks(iCov, block_size, debug=False):
         assert not debug or np.all(bu > 0), 'Found some negative iCov eigenvalues.'
         # Check that the eigenvectors are orthonormal so that vt.v = 1
         assert not debug or np.allclose(np.eye(len(bu)), bv.T.dot(bv))
+
+        if debug:
+            threshold = 10.0 * sys.float_info.epsilon
+            maxval = np.max(bu)
+            minval = np.sqrt(maxval) * threshold
+            i = np.sqrt(bu) > minval
+            if np.any(~i):
+                raise RuntimeError(f'Eigenvalue below minval {minval}: {bu[i]}')
+            # bu = np.clip(bu, minval, None)
+
         bQ = (bv * np.sqrt(1.0/bu)).dot(bv.T)
         Q[s] = bQ
     #- Calculate the corresponding resolution matrix and diagonal flux errors. (BS Eq 11-13)

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -477,7 +477,7 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, ps
         Rdiags = cp.zeros( (nspec, 2*ndiag+1, nwave) )
         xyslice = None
 
-    if cp.any(cp.isnan(fx)):
+    if cp.any(cp.isnan(specflux)):
         raise RuntimeError('Found NaN in extracted flux')
 
     Apadded = A4.reshape(ny*nx, nspecpad*nwavetot)

--- a/py/gpu_specter/io.py
+++ b/py/gpu_specter/io.py
@@ -26,6 +26,11 @@ def read_psf(filename):
     """
     psfdata = dict()
     psfdata['PSF'] = Table.read(filename, 'PSF')
+
+    if 'PSFERR' not in psfdata['PSF'].meta:
+        default_psferr = 0.01
+        print(f'Warning! PSFERR not found in PSF meta. Setting to {default_psferr}')
+        psfdata['PSF'].meta['PSFERR'] = default_psferr
     
     with fitsio.FITS(filename, 'r') as fx:
         for extname in ('XTRACE', 'YTRACE'):
@@ -55,7 +60,10 @@ def read_img(filename):
         mask = fx['MASK'].read()
         imgdata['ivar'][mask != 0] = 0.0
         imgdata['fibermap'] = fx['FIBERMAP'].read()
-        imgdata['fibermaphdr'] = fx['FIBERMAP'].read_header()
+        try:
+            imgdata['fibermaphdr'] = fx['FIBERMAP'].read_header()
+        except:
+            imgdata['fibermaphdr'] = None
 
     return imgdata
 

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -73,8 +73,7 @@ class TestCore(unittest.TestCase):
 
         keys = (
             'wave', 'specflux', 'specivar', 'Rdiags',
-            'pixmask_fraction', 'chi2pix', 'modelimage',
-            'imagehdr', 'fibermap', 'fibermaphdr'
+            'pixmask_fraction', 'chi2pix', 'modelimage'
         )
         for key in keys:
             self.assertTrue(key in frame.keys(), key)

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -71,7 +71,20 @@ class TestCore(unittest.TestCase):
             loglevel='WARN',
         )
 
+        keys = (
+            'wave', 'specflux', 'specivar', 'Rdiags',
+            'pixmask_fraction', 'chi2pix', 'modelimage',
+            'imagehdr', 'fibermap', 'fibermaphdr'
+        )
+        for key in keys:
+            self.assertTrue(key in frame.keys(), key)
+
+        self.assertEqual(frame['wave'].shape, (nwave, ))
         self.assertEqual(frame['specflux'].shape, (nspec, nwave))
+        self.assertEqual(frame['specivar'].shape, (nspec, nwave))
+        # self.assertEqual(frame['Rdiags'].shape, (nspec, ndiag, nwave))
+        self.assertEqual(frame['pixmask_fraction'].shape, (nspec, nwave))
+        self.assertEqual(frame['chi2pix'].shape, (nspec, nwave))
 
     @unittest.skipIf(not specter_available, 'specter not available')
     def test_compare_specter(self):


### PR DESCRIPTION
This PR adds the calculation of `chi2pix` and `pixmask_fraction`. It also adds support for `--psferr` option in `bin/spex`. 

All cpu/specter tests are passing using the latest desi environment on a cori haswell node.
All cpu/gpu tests are passing using the desi-gpu environment on a cori gpu node.