### PR TITLE
Add multi frame extraction script

### DIFF
--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -42,6 +42,8 @@ parser.add_argument("--gpu", action="store_true",
     help="use GPU")
 parser.add_argument("-v", "--verbose", action="store_true",
     help="print per-rank detailed timing")
+parser.add_argument("--old-format", action="store_true",
+    help="use old format for benchmark data filenames")
 args = parser.parse_args()
 
 start_time = args.start_time
@@ -130,8 +132,12 @@ frames_extracted = []
 for camera in group_cameras:
 
     #- Build extraction command
-    img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
-    psf_filename = f"{args.indir}/exposures/{night}/{expid}/psf-{camera}-{expid}.fits"
+    if args.old_format:
+        img_filename = f"{args.indir}/pix/{night}/pix-{camera}-{expid}.fits"
+        psf_filename = f"{args.indir}/psf/{night}/psfnight-{camera}.fits"
+    else:
+        img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
+        psf_filename = f"{args.indir}/exposures/{night}/{expid}/psf-{camera}-{expid}.fits"
     frame_filename = f"{args.outdir}/frame-{camera}-{expid}.fits"
 
     if not os.path.isfile(img_filename):

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -34,7 +34,7 @@ parser.add_argument("--expid", type=str, default="00055672",
 parser.add_argument("--spectrographs", type=str, default="0,1,2,3,4,5,6,7,8,9",
     help="Comma-separated list of spectrographs to extract")
 parser.add_argument("--colors", type=str,
-    help="Comma-separated list of colors to extract", default="b,r,z")
+    help="Comma-separated list of colors to extract", default="r,b,z")
 parser.add_argument("--cameras", type=str, default=None,
     help=("Comma separated list of cameras to extract. If not provided then the outer "
           "product of --spectrographs and --colors will be used to construct."))
@@ -58,20 +58,26 @@ startup_time = time.time()
 
 #- Divide MPI ranks into per node communication groups
 node = MPI.Get_processor_name()
-nodes = comm.allgather(node)
-nnodes = len(set(nodes))
-node_size = size // nnodes
 
-assert node_size * nnodes == size, \
-    f"Number of ranks {size} not divisible by number of nodes {nnodes}"
+group = node
+if args.gpu:
+    gpus = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+    group += ":" + gpus
 
-#- Assumes contiguous blocks of MPI ranks per node
-node_rank = rank % node_size
-node_index = rank // node_size
-node_comm = comm.Split(color=node_index, key=node_rank)
+groups = comm.allgather(group)
+ngroups = len(set(groups))
+group_size = size // ngroups
+
+assert group_size * ngroups == size, \
+    f"Number of ranks {size} not divisible by number of groups {ngroups}"
+
+#- Assumes contiguous blocks of MPI ranks per group
+group_rank = rank % group_size
+group_index = rank // group_size
+group_comm = comm.Split(color=group_index, key=group_rank)
 
 if rank == 0:
-    print(f"Splitting {size} ranks into {nnodes} groups of {node_size}")
+    print(f"Splitting {size} ranks into {ngroups} groups of {group_size}")
     sys.stdout.flush()
 
 #- Make sure input/output directories exist
@@ -104,24 +110,24 @@ if rank == 0:
     print(f"Extracting frames from cameras: {','.join(cameras)}")
     sys.stdout.flush()
 
-#- Divide cameras between nodes
-node_cameras = cameras[node_index::nnodes]
-if node_rank == 0:
-    print(f"{node}: {','.join(node_cameras)}")
+#- Divide cameras between groups
+group_cameras = cameras[group_index::ngroups]
+if group_rank == 0:
+    print(f"{group}: {','.join(group_cameras)}")
     sys.stdout.flush()
 
 ready_time = time.time()
 
 #- Initialize timing event log
 events = []
-events.append((node, rank, node_rank, None, "exposure-import", import_time - start_time))
-events.append((node, rank, node_rank, None, "exposure-startup-waiting", startup_waiting_time - start_time))
-events.append((node, rank, node_rank, None, "exposure-startup", startup_time - start_time))
-events.append((node, rank, node_rank, None, "exposure-ready", ready_time - start_time))
+events.append((group, rank, group_rank, None, "exposure-import", import_time - start_time))
+events.append((group, rank, group_rank, None, "exposure-startup-waiting", startup_waiting_time - start_time))
+events.append((group, rank, group_rank, None, "exposure-startup", startup_time - start_time))
+events.append((group, rank, group_rank, None, "exposure-ready", ready_time - start_time))
 
 #- Extract frames
 frames_extracted = []
-for camera in node_cameras:
+for camera in group_cameras:
 
     #- Build extraction command
     img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
@@ -129,12 +135,12 @@ for camera in node_cameras:
     frame_filename = f"{args.outdir}/frame-{camera}-{expid}.fits"
 
     if not os.path.isfile(img_filename):
-        if node_rank == 0:
+        if group_rank == 0:
             print("Skipping {camera}, image file does not exist: {img_filename}")
             sys.stdout.flush()
         continue
     if not os.path.isfile(psf_filename):
-        if node_rank == 0:
+        if group_rank == 0:
             print("Skipping {camera}, psf file does not exist: {psf_filename}")
             sys.stdout.flush()
         continue
@@ -165,7 +171,7 @@ for camera in node_cameras:
     if args.gpu:
         cmd = cmd + " --gpu"
 
-    if node_comm.rank == 0:
+    if group_comm.rank == 0:
         print(rank, cmd)
         sys.stdout.flush()
 
@@ -173,27 +179,28 @@ for camera in node_cameras:
     timing = dict()
 
     #- Perform extraction
-    extract.main_gpu_specter(cmd_args, comm=node_comm, timing=timing)
+    extract.main_gpu_specter(cmd_args, comm=group_comm, timing=timing)
 
     #- Save timing events from extraction
     for event_name in timing:
         event_time = timing[event_name]
-        events.append((node, rank, node_rank, camera, event_name, event_time - start_time))
+        events.append((group, rank, group_rank, camera, event_name, event_time - start_time))
 
     #- Mark successfully extracted frame
-    if node_comm.rank == 0:
+    if group_comm.rank == 0:
         frames_extracted.append(camera)
 
 #- Wait for all ranks
 end_waiting_time = time.time()
 comm.barrier()
 end_time = time.time()
-events.append((node, rank, node_rank, None, "exposure-end-waiting", end_waiting_time - start_time))
-events.append((node, rank, node_rank, None, "exposure-end", end_time - start_time))
+events.append((group, rank, group_rank, None, "exposure-end-waiting", end_waiting_time - start_time))
+events.append((group, rank, group_rank, None, "exposure-end", end_time - start_time))
 
 #- Collect metrics
 nframes = comm.reduce(len(frames_extracted), root=0)
 events = comm.gather(events, root=0)
+nodes = comm.gather(node, root=0)
 
 if rank == 0:
 
@@ -207,6 +214,7 @@ if rank == 0:
         writer.writerows(events)
 
     #- Print summary
+    nnodes = len(set(nodes))
     elapsed_time = end_time - start_time
     node_hours = nnodes * elapsed_time / (60 * 60)
     work_rate = nframes / node_hours
@@ -215,3 +223,15 @@ if rank == 0:
     print("desi-extract effective work rate = {:.2f} frames per node-hour".format(work_rate))
     print("desi-extract startup time: {:.1f} sec".format(startup_time - start_time))
     print("desi-extract elapsed time: {:.1f} sec".format(elapsed_time))
+
+    if args.gpu:
+        unique_devices = set()
+        for group in set(groups):
+            node, devices = group.split(":")
+            for device in devices.split(","):
+                unique_devices.add(node + ":" + device)
+        ngpus = len(unique_devices)
+
+        gpu_hours = ngpus * elapsed_time / (60 * 60)
+        gpu_work_rate = nframes / gpu_hours
+        print("desi-extract gpu work rate = {:.2f} frames per gpu-hour".format(gpu_work_rate))

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -8,11 +8,15 @@ srun -n 160 -c 2 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inpu
 srun -n 20 -c 1 python bin/desi-extract-exposure /global/cfs/cdirs/desi/spectro/redux/andes $SCRATCH/temp $(date +%s)
 """
 
+import time
+
+import_time = time.time()
+
 import argparse
+import csv
 import glob 
 import os
 import sys
-import time
 
 from desispec.scripts import extract
 
@@ -35,6 +39,36 @@ parser.add_argument("--gpu", action="store_true", help="use GPU")
 parser.add_argument("-v", "--verbose", action="store_true", help="print per-rank detailed timing")
 args = parser.parse_args()
 
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+comm.barrier()
+start_time = args.start_time
+startup_time = time.time()
+
+# split comm by node
+node = MPI.Get_processor_name()
+nodes = comm.allgather(node)
+nnodes = len(set(nodes))
+node_size = size // nnodes
+
+assert node_size * nnodes == size, \
+    f"Number of ranks {size} not divisible by number of nodes {nnodes}"
+
+node_rank = rank % node_size
+node_index = rank // node_size
+node_comm = comm.Split(color=node_index, key=node_rank)
+
+if rank == 0:
+    print(f"Splitting {size} ranks into {nnodes} groups of {node_size}")
+    sys.stdout.flush()
+
+assert os.path.exists(args.indir)
+assert os.path.exists(args.outdir)
+
 # TODO: validate night/expid
 night = args.night
 expid = args.expid
@@ -55,51 +89,31 @@ for camera in cameras:
     assert int(spectrograph) in range(10), \
         f"{spectrograph} is not a valid spectrograph {camera}"
 
-# TODO: check for valid cameras
-
-assert os.path.exists(args.indir)
-assert os.path.exists(args.outdir)
-
-from mpi4py import MPI
-
-comm = MPI.COMM_WORLD
-rank = comm.rank
-size = comm.size
-
 if rank == 0:
     print(f"Extracting frames from cameras: {','.join(cameras)}")
     sys.stdout.flush()
-
-comm.barrier()
-if rank == 0:
-    start_time = args.start_time
-    startup_time = time.time() - start_time
-
-# split comm by node
-node = MPI.Get_processor_name()
-nodes = comm.allgather(node)
-nnodes = len(set(nodes))
-node_size = size // nnodes
-
-assert node_size * nnodes == size, \
-    f"Number of ranks {size} not divisible by number of nodes {nnodes}"
-
-node_rank = rank % node_size
-node_index = rank // node_size
-node_comm = comm.Split(color=node_index, key=node_rank)
-
-if rank == 0:
-    print(f"Splitting {size} ranks into {nnodes} groups of {node_size}")
-    sys.stdout.flush()
-
-frames_extracted = []
 
 node_cameras = cameras[node_index::nnodes]
 if node_rank == 0:
     print(f"{node}: {','.join(node_cameras)}")
     sys.stdout.flush()
 
-for camera in cameras[node_index::nnodes]:
+ready_time = time.time()
+
+events = []
+events.append(
+    (node, rank, node_rank, None, "exposure-import", import_time - start_time)
+)
+events.append(
+    (node, rank, node_rank, None, "exposure-startup", startup_time - start_time)
+)
+events.append(
+    (node, rank, node_rank, None, "exposure-ready", ready_time - start_time)
+)
+
+frames_extracted = []
+
+for camera in node_cameras:
 
     img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
     psf_filename = f"{args.indir}/exposures/{night}/{expid}/psf-{camera}-{expid}.fits"
@@ -147,21 +161,37 @@ for camera in cameras[node_index::nnodes]:
         sys.stdout.flush()
 
     cmd_args = extract.parse(cmd.split()[1:])
-    extract.main_gpu_specter(cmd_args, comm=node_comm)
+    timing = dict()
+    extract.main_gpu_specter(cmd_args, comm=node_comm, timing=timing)
+
+    for event_name in timing:
+        event_time = timing[event_name]
+        events.append((node, rank, node_rank, camera, event_name, event_time - start_time))
 
     if node_comm.rank == 0:
         frames_extracted.append(camera)
 
 comm.barrier()
 end_time = time.time()
+events.append((node, rank, node_rank, None, "exposure-end", end_time - start_time))
 
 nframes = comm.reduce(len(frames_extracted), root=0)
+events = comm.gather(events, root=0)
 if rank == 0:
+
+    def flatten(l):
+        return [i for s in l for i in s]
+    events = flatten(events)
+    events_filename = f"{args.outdir}/events-{night}-{expid}.csv"
+    with open(events_filename, "w") as f:
+        writer = csv.writer(f)
+        writer.writerows(events)
+
     elapsed_time = end_time - start_time
     node_hours = nnodes * elapsed_time / (60 * 60)
     work_rate = nframes / node_hours
 
     print("desi-extract {} effective frames in {:.1f} min".format(nframes, elapsed_time / 60))
     print("desi-extract effective work rate = {:.2f} frames per node-hour".format(work_rate))
-    print("desi-extract startup time: {:.1f} sec".format(startup_time))
+    print("desi-extract startup time: {:.1f} sec".format(startup_time - start_time))
     print("desi-extract elapsed time: {:.1f} sec".format(elapsed_time))

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+"""
+DESI spectral extraction code benchmark
+salloc -N 5 -t 2:00:00 -C haswell -q interactive
+srun -n 160 -c 2 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inputs/ -o $SCRATCH/temp $(date +%s)
+
+
+
+srun -n 20 -c 1 python bin/desi-extract-exposure /global/cfs/cdirs/desi/spectro/redux/andes $SCRATCH/temp $(date +%s)
+"""
+
+import argparse
+import glob 
+import os
+import pprint
+import socket
+import random
+import sys
+import time
+
+from desispec.scripts import extract
+
+random.seed(1)
+
+#- Parse args before initializing MPI so that --help will work anywhere
+
+parser = argparse.ArgumentParser()
+parser.add_argument("indir", help="input data directory")
+parser.add_argument("outdir", help="output directory")
+parser.add_argument("start_time", help="use $(date +%%s)", type=float)
+# parser.add_argument("--night", type=str, help="YEARMMDD to extract", default="*")
+# parser.add_argument("--expid", type=str, help="Exposure ID to extract", default="*")
+parser.add_argument("-v", "--verbose", action="store_true", help="print per-rank detailed timing")
+args = parser.parse_args()
+
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+rank = comm.rank
+size = comm.size
+
+comm.barrier()
+if rank == 0:
+    start_time = args.start_time
+    startup_time = time.time() - start_time
+
+
+# if rank == 0:
+#     assert os.path.exists(args.outdir)
+#     pixfiles = sorted(glob.glob(args.indir + \
+#             "/pix/{}/pix-{}?-{}.fits".format(
+#             args.night, args.camera, args.expid)))
+
+#     random.shuffle(pixfiles)
+#     assert len(pixfiles) > 0
+#     assert nframe <= len(pixfiles)
+#     pixfiles = pixfiles[0:nframe]
+# else:
+#     pixfiles = None
+
+# pixfiles = comm.bcast(pixfiles, root=0)
+# assert nframe == len(pixfiles)
+
+# split comm by host
+host = MPI.Get_processor_name()
+hosts = comm.allgather(host)
+nhosts = len(set(hosts))
+
+host_size = size // nhosts
+host_rank = rank % host_size
+host_index = rank // host_size
+host_comm = comm.Split(color=host_index, key=host_rank)
+
+if rank == 0:
+    print(f'Splitting {size} into {nhosts} communicators')
+    sys.stdout.flush()
+
+# print(f'{rank:3d}/{size}: {host} {host_comm.rank:2d}/{host_comm.size}')
+
+# if rank == 0:
+#     print("{} input frames".format(nframe))
+#     print("Splitting {} ranks into {} communicators".format(size, nframe))
+#     sys.stdout.flush()
+
+# comm.barrier()
+
+# group = rank // bundles_per_frame
+# group_rank =  rank % bundles_per_frame
+
+# comm_group = comm.Split(color=group, key=group_rank)
+# assert comm_group.rank == group_rank
+
+# channels = "brz"
+# spectrographs = tuple(range(10))
+
+night = "20200315"
+expid = "00055672"
+# camera = "r0"
+
+cameras = [f"{color}{spec}" for spec in range(10) for color in "brz"]
+
+finished = []
+
+for camera in cameras[host_index::nhosts]:
+
+    img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
+    psf_filename = f"{args.indir}/exposures/{night}/{expid}/psf-{camera}-{expid}.fits"
+    frame_filename = f"{args.outdir}/frame-{camera}-{expid}.fits"
+
+    cmd = \
+        "desi_extract_spectra --mpi" \
+        f" -i {img_filename}" \
+        f" -p {psf_filename}" \
+        f" -o {frame_filename}"
+
+    #- DEBUG speed
+    # if camera.startswith("b"):
+    #     cmd = cmd + " -w 4000,4200,1"
+    # elif camera.startswith("r"):
+    #     cmd = cmd + " -w 6000,6200,1"
+    # elif camera.startswith("z"):
+    #     cmd = cmd + " -w 9000,9200,1"
+
+    if camera.startswith("b"):
+        cmd = cmd + " -w 3600.0,5800.0,0.8"
+    elif camera.startswith("r"):
+        cmd = cmd + " -w 5760.0,7620.0,0.8"
+    elif camera.startswith("z"):
+        cmd = cmd + " -w 7520.0,9824.0,0.8"
+
+    cmd = cmd + " --gpu-specter --nsubbundles 5"
+
+    # if comm_group.rank == 0:
+    #     print(rank, cmd)
+    #     sys.stdout.flush()
+
+    if host_comm.rank == 0:
+        print(rank, cmd)
+        sys.stdout.flush()
+
+    cmd_args = extract.parse(cmd.split()[1:])
+    timing = dict()
+    # extract.main_mpi(cmd_args, comm=comm_group, timing=timing)
+    extract.main_gpu_specter(cmd_args, comm=host_comm)
+
+    finished.append(camera)
+
+comm.barrier()
+end_time = time.time()
+
+# timings = comm.gather(timing, root=0)
+hostnames = comm.gather(socket.gethostname(), root=0)
+finished = comm.gather(finished, root=0)
+if rank == 0:
+    nframe = len(cameras)
+    num_nodes = len(set(hostnames))
+    node_hours = num_nodes * (end_time - start_time) / (60*60)
+    work_rate = nframe / node_hours
+
+    # if args.verbose:
+    #     pprint.pprint(timings)
+
+    print("desi-extract {} effective frames in {:.1f} min".format(nframe, (end_time - start_time)/60))
+    print("desi-extract effective work rate = {:.2f} frames per node-hour".format(work_rate))
+    print("desi-extract startup time: {:.1f} sec".format(startup_time))
+    print("desi-extract elapsed time: {:.1f} sec".format(end_time - start_time))

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -5,8 +5,6 @@ DESI spectral extraction code benchmark
 salloc -N 5 -t 2:00:00 -C haswell -q interactive
 srun -n 160 -c 2 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inputs/ -o $SCRATCH/temp $(date +%s)
 
-
-
 srun -n 20 -c 1 python bin/desi-extract-exposure /global/cfs/cdirs/desi/spectro/redux/andes $SCRATCH/temp $(date +%s)
 """
 
@@ -29,10 +27,37 @@ parser = argparse.ArgumentParser()
 parser.add_argument("indir", help="input data directory")
 parser.add_argument("outdir", help="output directory")
 parser.add_argument("start_time", help="use $(date +%%s)", type=float)
-# parser.add_argument("--night", type=str, help="YEARMMDD to extract", default="*")
-# parser.add_argument("--expid", type=str, help="Exposure ID to extract", default="*")
+parser.add_argument("--night", type=str, help="YYYYMMDD to extract", default="20200315")
+parser.add_argument("--expid", type=str, help="Exposure ID to extract", default="00055672")
+parser.add_argument("--spectrographs", type=str, help="Comma-separated list of spectrographs to extract", default='0,1,2,3,4,5,6,7,8,9')
+parser.add_argument("--colors", type=str, help="Comma-separated list of colors to extract", default='b,r,z')
+parser.add_argument("--cameras", type=str, help="Comma separated list of cameras to extract. If not provided then the outer product of --spectrographs and --colors will be used to construct.", default=None)
+parser.add_argument("--gpu", action="store_true", help="use GPU")
 parser.add_argument("-v", "--verbose", action="store_true", help="print per-rank detailed timing")
 args = parser.parse_args()
+
+# TODO: validate night/expid
+night = args.night
+expid = args.expid
+
+if args.cameras is None:
+    spectrographs = args.spectrographs.split(',')
+    colors = args.colors.split(',')
+    cameras = [
+        f"{color}{spec}" for spec in spectrographs for color in colors
+    ]
+else:
+    cameras = args.cameras.split(',')
+
+for camera in cameras:
+    color, spectrograph = camera
+    assert color in 'brz', f'{color} is not a valid color {camera}'
+    assert int(spectrograph) in range(10), f'{spectrograph} is not a valid spectrograph {camera}'
+
+# TODO: check for valid cameras
+
+assert os.path.exists(args.indir)
+assert os.path.exists(args.outdir)
 
 from mpi4py import MPI
 
@@ -40,73 +65,52 @@ comm = MPI.COMM_WORLD
 rank = comm.rank
 size = comm.size
 
+if rank == 0:
+    print(f"Extracting frames from cameras: {','.join(cameras)}")
+    sys.stdout.flush()
+
 comm.barrier()
 if rank == 0:
     start_time = args.start_time
     startup_time = time.time() - start_time
 
+# split comm by node
+node = MPI.Get_processor_name()
+nodes = comm.allgather(node)
+nnodes = len(set(nodes))
+node_size = size // nnodes
 
-# if rank == 0:
-#     assert os.path.exists(args.outdir)
-#     pixfiles = sorted(glob.glob(args.indir + \
-#             "/pix/{}/pix-{}?-{}.fits".format(
-#             args.night, args.camera, args.expid)))
+assert node_size * nnodes == size, \
+    f"Number of ranks {size} not divisible by number of nodes {nnodes}"
 
-#     random.shuffle(pixfiles)
-#     assert len(pixfiles) > 0
-#     assert nframe <= len(pixfiles)
-#     pixfiles = pixfiles[0:nframe]
-# else:
-#     pixfiles = None
-
-# pixfiles = comm.bcast(pixfiles, root=0)
-# assert nframe == len(pixfiles)
-
-# split comm by host
-host = MPI.Get_processor_name()
-hosts = comm.allgather(host)
-nhosts = len(set(hosts))
-
-host_size = size // nhosts
-host_rank = rank % host_size
-host_index = rank // host_size
-host_comm = comm.Split(color=host_index, key=host_rank)
+node_rank = rank % node_size
+node_index = rank // node_size
+node_comm = comm.Split(color=node_index, key=node_rank)
 
 if rank == 0:
-    print(f'Splitting {size} into {nhosts} communicators')
+    print(f'Splitting {size} ranks into {nnodes} groups of {node_size}')
     sys.stdout.flush()
 
-# print(f'{rank:3d}/{size}: {host} {host_comm.rank:2d}/{host_comm.size}')
+frames_extracted = []
 
-# if rank == 0:
-#     print("{} input frames".format(nframe))
-#     print("Splitting {} ranks into {} communicators".format(size, nframe))
-#     sys.stdout.flush()
+node_cameras = cameras[node_index::nnodes]
+if node_rank == 0:
+    print(f"{node}: {','.join(node_cameras)}")
 
-# comm.barrier()
-
-# group = rank // bundles_per_frame
-# group_rank =  rank % bundles_per_frame
-
-# comm_group = comm.Split(color=group, key=group_rank)
-# assert comm_group.rank == group_rank
-
-# channels = "brz"
-# spectrographs = tuple(range(10))
-
-night = "20200315"
-expid = "00055672"
-# camera = "r0"
-
-cameras = [f"{color}{spec}" for spec in range(10) for color in "brz"]
-
-finished = []
-
-for camera in cameras[host_index::nhosts]:
+for camera in cameras[node_index::nnodes]:
 
     img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
     psf_filename = f"{args.indir}/exposures/{night}/{expid}/psf-{camera}-{expid}.fits"
     frame_filename = f"{args.outdir}/frame-{camera}-{expid}.fits"
+
+    if not os.path.isfile(img_filename):
+        if node_rank == 0:
+            print('Skipping {camera}, image file does not exist: {img_filename}')
+        continue
+    if not os.path.isfile(psf_filename):
+        if node_rank == 0:
+            print('Skipping {camera}, psf file does not exist: {psf_filename}')
+        continue
 
     cmd = \
         "desi_extract_spectra --mpi" \
@@ -131,37 +135,29 @@ for camera in cameras[host_index::nhosts]:
 
     cmd = cmd + " --gpu-specter --nsubbundles 5"
 
-    # if comm_group.rank == 0:
-    #     print(rank, cmd)
-    #     sys.stdout.flush()
+    if args.gpu:
+        cmd = cmd + " --gpu"
 
-    if host_comm.rank == 0:
+    if node_comm.rank == 0:
         print(rank, cmd)
         sys.stdout.flush()
 
     cmd_args = extract.parse(cmd.split()[1:])
-    timing = dict()
-    # extract.main_mpi(cmd_args, comm=comm_group, timing=timing)
-    extract.main_gpu_specter(cmd_args, comm=host_comm)
+    extract.main_gpu_specter(cmd_args, comm=node_comm)
 
-    finished.append(camera)
+    if node_comm.rank == 0:
+        frames_extracted.append(camera)
 
 comm.barrier()
 end_time = time.time()
 
-# timings = comm.gather(timing, root=0)
-hostnames = comm.gather(socket.gethostname(), root=0)
-finished = comm.gather(finished, root=0)
+nframes = comm.reduce(len(frames_extracted), root=0)
 if rank == 0:
-    nframe = len(cameras)
-    num_nodes = len(set(hostnames))
-    node_hours = num_nodes * (end_time - start_time) / (60*60)
-    work_rate = nframe / node_hours
+    elapsed_time = end_time - start_time
+    node_hours = nnodes * elapsed_time / (60 * 60)
+    work_rate = nframes / node_hours
 
-    # if args.verbose:
-    #     pprint.pprint(timings)
-
-    print("desi-extract {} effective frames in {:.1f} min".format(nframe, (end_time - start_time)/60))
+    print("desi-extract {} effective frames in {:.1f} min".format(nframes, elapsed_time / 60))
     print("desi-extract effective work rate = {:.2f} frames per node-hour".format(work_rate))
     print("desi-extract startup time: {:.1f} sec".format(startup_time))
-    print("desi-extract elapsed time: {:.1f} sec".format(end_time - start_time))
+    print("desi-extract elapsed time: {:.1f} sec".format(elapsed_time))

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -3,9 +3,7 @@
 """
 DESI spectral extraction code benchmark
 salloc -N 5 -t 2:00:00 -C haswell -q interactive
-srun -n 160 -c 2 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inputs/ -o $SCRATCH/temp $(date +%s)
-
-srun -n 20 -c 1 python bin/desi-extract-exposure /global/cfs/cdirs/desi/spectro/redux/andes $SCRATCH/temp $(date +%s)
+srun -n 160 -c 2 python bin/desi-extract-exposure /global/cfs/cdirs/desi/spectro/redux/andes $SCRATCH/temp $(date +%s)
 """
 
 import time
@@ -23,21 +21,30 @@ from desispec.scripts import extract
 #- Parse args before initializing MPI so that --help will work anywhere
 
 parser = argparse.ArgumentParser()
-parser.add_argument("indir", help="input data directory")
-parser.add_argument("outdir", help="output directory")
-parser.add_argument("start_time", help="use $(date +%%s)", type=float)
-parser.add_argument("--night", type=str, help="YYYYMMDD to extract", default="20200315")
-parser.add_argument("--expid", type=str, help="Exposure ID to extract", default="00055672")
-parser.add_argument("--spectrographs", type=str,
-    help="Comma-separated list of spectrographs to extract", default="0,1,2,3,4,5,6,7,8,9")
+parser.add_argument("indir",
+    help="input data directory")
+parser.add_argument("outdir",
+    help="output directory")
+parser.add_argument("start_time", type=float,
+    help="use $(date +%%s)")
+parser.add_argument("--night", type=str, default="20200315",
+    help="YYYYMMDD to extract")
+parser.add_argument("--expid", type=str, default="00055672",
+    help="Exposure ID to extract")
+parser.add_argument("--spectrographs", type=str, default="0,1,2,3,4,5,6,7,8,9",
+    help="Comma-separated list of spectrographs to extract")
 parser.add_argument("--colors", type=str,
     help="Comma-separated list of colors to extract", default="b,r,z")
 parser.add_argument("--cameras", type=str, default=None,
     help=("Comma separated list of cameras to extract. If not provided then the outer "
           "product of --spectrographs and --colors will be used to construct."))
-parser.add_argument("--gpu", action="store_true", help="use GPU")
-parser.add_argument("-v", "--verbose", action="store_true", help="print per-rank detailed timing")
+parser.add_argument("--gpu", action="store_true",
+    help="use GPU")
+parser.add_argument("-v", "--verbose", action="store_true",
+    help="print per-rank detailed timing")
 args = parser.parse_args()
+
+start_time = args.start_time
 
 from mpi4py import MPI
 
@@ -45,11 +52,11 @@ comm = MPI.COMM_WORLD
 rank = comm.rank
 size = comm.size
 
+startup_waiting_time = time.time()
 comm.barrier()
-start_time = args.start_time
 startup_time = time.time()
 
-# split comm by node
+#- Divide MPI ranks into per node communication groups
 node = MPI.Get_processor_name()
 nodes = comm.allgather(node)
 nnodes = len(set(nodes))
@@ -58,6 +65,7 @@ node_size = size // nnodes
 assert node_size * nnodes == size, \
     f"Number of ranks {size} not divisible by number of nodes {nnodes}"
 
+#- Assumes contiguous blocks of MPI ranks per node
 node_rank = rank % node_size
 node_index = rank // node_size
 node_comm = comm.Split(color=node_index, key=node_rank)
@@ -66,13 +74,15 @@ if rank == 0:
     print(f"Splitting {size} ranks into {nnodes} groups of {node_size}")
     sys.stdout.flush()
 
+#- Make sure input/output directories exist
 assert os.path.exists(args.indir)
 assert os.path.exists(args.outdir)
 
-# TODO: validate night/expid
+#- TODO: validate night/expid ?
 night = args.night
 expid = args.expid
 
+#- Construct list of cameras to extract
 if args.cameras is None:
     spectrographs = args.spectrographs.split(",")
     colors = args.colors.split(",")
@@ -82,6 +92,7 @@ if args.cameras is None:
 else:
     cameras = args.cameras.split(",")
 
+#- Check for valid DESI cameras
 for camera in cameras:
     color, spectrograph = camera
     assert color in "brz", \
@@ -93,6 +104,7 @@ if rank == 0:
     print(f"Extracting frames from cameras: {','.join(cameras)}")
     sys.stdout.flush()
 
+#- Divide cameras between nodes
 node_cameras = cameras[node_index::nnodes]
 if node_rank == 0:
     print(f"{node}: {','.join(node_cameras)}")
@@ -100,21 +112,18 @@ if node_rank == 0:
 
 ready_time = time.time()
 
+#- Initialize timing event log
 events = []
-events.append(
-    (node, rank, node_rank, None, "exposure-import", import_time - start_time)
-)
-events.append(
-    (node, rank, node_rank, None, "exposure-startup", startup_time - start_time)
-)
-events.append(
-    (node, rank, node_rank, None, "exposure-ready", ready_time - start_time)
-)
+events.append((node, rank, node_rank, None, "exposure-import", import_time - start_time))
+events.append((node, rank, node_rank, None, "exposure-startup-waiting", startup_waiting_time - start_time))
+events.append((node, rank, node_rank, None, "exposure-startup", startup_time - start_time))
+events.append((node, rank, node_rank, None, "exposure-ready", ready_time - start_time))
 
+#- Extract frames
 frames_extracted = []
-
 for camera in node_cameras:
 
+    #- Build extraction command
     img_filename = f"{args.indir}/preproc/{night}/{expid}/preproc-{camera}-{expid}.fits"
     psf_filename = f"{args.indir}/exposures/{night}/{expid}/psf-{camera}-{expid}.fits"
     frame_filename = f"{args.outdir}/frame-{camera}-{expid}.fits"
@@ -162,23 +171,33 @@ for camera in node_cameras:
 
     cmd_args = extract.parse(cmd.split()[1:])
     timing = dict()
+
+    #- Perform extraction
     extract.main_gpu_specter(cmd_args, comm=node_comm, timing=timing)
 
+    #- Save timing events from extraction
     for event_name in timing:
         event_time = timing[event_name]
         events.append((node, rank, node_rank, camera, event_name, event_time - start_time))
 
+    #- Mark successfully extracted frame
     if node_comm.rank == 0:
         frames_extracted.append(camera)
 
+#- Wait for all ranks
+end_waiting_time = time.time()
 comm.barrier()
 end_time = time.time()
+events.append((node, rank, node_rank, None, "exposure-end-waiting", end_waiting_time - start_time))
 events.append((node, rank, node_rank, None, "exposure-end", end_time - start_time))
 
+#- Collect metrics
 nframes = comm.reduce(len(frames_extracted), root=0)
 events = comm.gather(events, root=0)
+
 if rank == 0:
 
+    #- Save event log to csv file
     def flatten(l):
         return [i for s in l for i in s]
     events = flatten(events)
@@ -187,6 +206,7 @@ if rank == 0:
         writer = csv.writer(f)
         writer.writerows(events)
 
+    #- Print summary
     elapsed_time = end_time - start_time
     node_hours = nnodes * elapsed_time / (60 * 60)
     work_rate = nframes / node_hours

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -11,15 +11,10 @@ srun -n 20 -c 1 python bin/desi-extract-exposure /global/cfs/cdirs/desi/spectro/
 import argparse
 import glob 
 import os
-import pprint
-import socket
-import random
 import sys
 import time
 
 from desispec.scripts import extract
-
-random.seed(1)
 
 #- Parse args before initializing MPI so that --help will work anywhere
 
@@ -29,9 +24,13 @@ parser.add_argument("outdir", help="output directory")
 parser.add_argument("start_time", help="use $(date +%%s)", type=float)
 parser.add_argument("--night", type=str, help="YYYYMMDD to extract", default="20200315")
 parser.add_argument("--expid", type=str, help="Exposure ID to extract", default="00055672")
-parser.add_argument("--spectrographs", type=str, help="Comma-separated list of spectrographs to extract", default='0,1,2,3,4,5,6,7,8,9')
-parser.add_argument("--colors", type=str, help="Comma-separated list of colors to extract", default='b,r,z')
-parser.add_argument("--cameras", type=str, help="Comma separated list of cameras to extract. If not provided then the outer product of --spectrographs and --colors will be used to construct.", default=None)
+parser.add_argument("--spectrographs", type=str,
+    help="Comma-separated list of spectrographs to extract", default="0,1,2,3,4,5,6,7,8,9")
+parser.add_argument("--colors", type=str,
+    help="Comma-separated list of colors to extract", default="b,r,z")
+parser.add_argument("--cameras", type=str, default=None,
+    help=("Comma separated list of cameras to extract. If not provided then the outer "
+          "product of --spectrographs and --colors will be used to construct."))
 parser.add_argument("--gpu", action="store_true", help="use GPU")
 parser.add_argument("-v", "--verbose", action="store_true", help="print per-rank detailed timing")
 args = parser.parse_args()
@@ -41,18 +40,20 @@ night = args.night
 expid = args.expid
 
 if args.cameras is None:
-    spectrographs = args.spectrographs.split(',')
-    colors = args.colors.split(',')
+    spectrographs = args.spectrographs.split(",")
+    colors = args.colors.split(",")
     cameras = [
         f"{color}{spec}" for spec in spectrographs for color in colors
     ]
 else:
-    cameras = args.cameras.split(',')
+    cameras = args.cameras.split(",")
 
 for camera in cameras:
     color, spectrograph = camera
-    assert color in 'brz', f'{color} is not a valid color {camera}'
-    assert int(spectrograph) in range(10), f'{spectrograph} is not a valid spectrograph {camera}'
+    assert color in "brz", \
+        f"{color} is not a valid color {camera}"
+    assert int(spectrograph) in range(10), \
+        f"{spectrograph} is not a valid spectrograph {camera}"
 
 # TODO: check for valid cameras
 
@@ -88,7 +89,7 @@ node_index = rank // node_size
 node_comm = comm.Split(color=node_index, key=node_rank)
 
 if rank == 0:
-    print(f'Splitting {size} ranks into {nnodes} groups of {node_size}')
+    print(f"Splitting {size} ranks into {nnodes} groups of {node_size}")
     sys.stdout.flush()
 
 frames_extracted = []
@@ -96,6 +97,7 @@ frames_extracted = []
 node_cameras = cameras[node_index::nnodes]
 if node_rank == 0:
     print(f"{node}: {','.join(node_cameras)}")
+    sys.stdout.flush()
 
 for camera in cameras[node_index::nnodes]:
 
@@ -105,11 +107,13 @@ for camera in cameras[node_index::nnodes]:
 
     if not os.path.isfile(img_filename):
         if node_rank == 0:
-            print('Skipping {camera}, image file does not exist: {img_filename}')
+            print("Skipping {camera}, image file does not exist: {img_filename}")
+            sys.stdout.flush()
         continue
     if not os.path.isfile(psf_filename):
         if node_rank == 0:
-            print('Skipping {camera}, psf file does not exist: {psf_filename}')
+            print("Skipping {camera}, psf file does not exist: {psf_filename}")
+            sys.stdout.flush()
         continue
 
     cmd = \

--- a/bin/mps-wrapper
+++ b/bin/mps-wrapper
@@ -22,6 +22,10 @@ fi
 
 sleep 5
 
+if [ $NODE_RANK -eq 0 ]; then
+    echo "mps ready: $(date --iso-8601=seconds)"
+fi
+
 # run the command
 "$@"
 

--- a/bin/mps-wrapper
+++ b/bin/mps-wrapper
@@ -12,7 +12,11 @@ export CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-log
 # export CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=$((100 / $SLURM_NTASKS))
 # export CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=$((200 / $SLURM_NTASKS))
 
-if [ $SLURM_PROCID -eq 0 ]; then
+NTASKS_PER_NODE=$((SLURM_NTASKS / SLURM_NNODES))
+NODE_RANK=$((SLURM_PROCID % NTASKS_PER_NODE))
+
+if [ $NODE_RANK -eq 0 ]; then
+    echo $SLURM_PROCID starting nvidia-cuda-mps-control on $(hostname)
     nvidia-cuda-mps-control -d
 fi
 
@@ -21,6 +25,7 @@ sleep 5
 # run the command
 "$@"
 
-if [ $SLURM_PROCID -eq 0 ]; then
+if [ $NODE_RANK -eq 0 ]; then
+    echo $SLURM_PROCID stopping nvidia-cuda-mps-control on $(hostname)
     echo quit | nvidia-cuda-mps-control
 fi

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -349,7 +349,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                 # bundle = tuple(cp.asnumpy(x) for x in bundle)
                 cp.cuda.nvtx.RangePop()
         timer.split('assembled patches')
-        timer.log_splits(log)
+        # timer.log_splits(log)
     return bundle
 
 
@@ -480,8 +480,8 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
     bspecmins = list(range(specmin, specmin+nspec, bundlesize))
     bundles = list()
     for bspecmin in bspecmins[bundle_start::bundle_step]:
-        log.info(f'Rank {rank}: Extracting spectra [{bspecmin}:{bspecmin+bundlesize}]')
-        sys.stdout.flush()
+        # log.info(f'Rank {rank}: Extracting spectra [{bspecmin}:{bspecmin+bundlesize}]')
+        # sys.stdout.flush()
         if gpu:
             cp.cuda.nvtx.RangePush('extract_bundle')
         bundle = extract_bundle(


### PR DESCRIPTION
This PR adds `bin/desi-extract-exposure` for extracting all 30 frames in a single DESI exposure. Frames are divided among nodes and then processed sequentially. 

The following figure demonstrates how frames are split among nodes for an example run on corigpu using 5 nodes, 4 GPUs per node, and 8 tasks per node:

![image](https://user-images.githubusercontent.com/1648834/90566497-6de2a700-e15d-11ea-97b7-3f9e6a5ef461.png)

The effective work rate is ~100 frames per node-hour including startup time.

Another example using just 2 nodes:

![image](https://user-images.githubusercontent.com/1648834/90567545-2b21ce80-e15f-11ea-831d-593667bd344d.png)

The effective work rate is now ~120 frames per node-hour including startup time (which is absorbed by longer overall runtime in this case).
