### PR TITLE
Batch subbundle extraction on GPU

### DIFF
--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -48,6 +48,8 @@ parser.add_argument("--model", action="store_true", required=False,
     help="output 2D pixel model file")
 parser.add_argument("--nwavestep", type=int, default=30,
     help="patch size parameter")
+parser.add_argument("--barycentric-correction", action="store_true",
+    help="apply barycentric correction to wavelength")
 args = parser.parse_args()
 
 start_time = args.start_time
@@ -179,6 +181,9 @@ for camera in group_cameras:
     cmd = cmd + " --gpu-specter --nsubbundles 5"
 
     cmd = cmd + f" --nwavestep {args.nwavestep}"
+
+    if args.barycentric_correction:
+        cmd += " --barycentric-correction"
 
     if args.model:
         model_filename = frame_filename.rstrip(".fits") + "-model.fits"

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -44,7 +44,10 @@ parser.add_argument("-v", "--verbose", action="store_true",
     help="print per-rank detailed timing")
 parser.add_argument("--old-format", action="store_true",
     help="use old format for benchmark data filenames")
-parser.add_argument("--model", action="store_true", required=False, help="output 2D pixel model file")
+parser.add_argument("--model", action="store_true", required=False,
+    help="output 2D pixel model file")
+parser.add_argument("--nwavestep", type=int, default=30,
+    help="patch size parameter")
 args = parser.parse_args()
 
 start_time = args.start_time
@@ -175,6 +178,8 @@ for camera in group_cameras:
 
     cmd = cmd + " --gpu-specter --nsubbundles 5"
 
+    cmd = cmd + f" --nwavestep {args.nwavestep}"
+
     if args.model:
         model_filename = frame_filename.rstrip(".fits") + "-model.fits"
         cmd = cmd + f" --model {model_filename}"
@@ -230,8 +235,13 @@ if rank == 0:
     node_hours = nnodes * elapsed_time / (60 * 60)
     work_rate = nframes / node_hours
 
-    print("desi-extract {} effective frames in {:.1f} min".format(nframes, elapsed_time / 60))
+    extraction_time = end_time - startup_time
+    extraction_node_hours = nnodes * extraction_time / (60 * 60)
+    extraction_work_rate = nframes / extraction_node_hours
+
+    print("desi-extract {} frames in {:.1f} min".format(nframes, elapsed_time / 60))
     print("desi-extract effective work rate = {:.2f} frames per node-hour".format(work_rate))
+    print("desi-extract extraction work rate = {:.2f} frames per node-hour".format(extraction_work_rate))
     print("desi-extract startup time: {:.1f} sec".format(startup_time - start_time))
     print("desi-extract elapsed time: {:.1f} sec".format(elapsed_time))
 
@@ -245,4 +255,9 @@ if rank == 0:
 
         gpu_hours = ngpus * elapsed_time / (60 * 60)
         gpu_work_rate = nframes / gpu_hours
-        print("desi-extract gpu work rate = {:.2f} frames per gpu-hour".format(gpu_work_rate))
+
+        gpu_extraction_hours = ngpus * extraction_time / (60 * 60)
+        gpu_extraction_work_rate = nframes / gpu_extraction_hours
+
+        print("desi-extract gpu effective work rate = {:.2f} frames per gpu-hour".format(gpu_work_rate))
+        print("desi-extract gpu extraction work rate = {:.2f} frames per gpu-hour".format(gpu_extraction_work_rate))

--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -44,6 +44,7 @@ parser.add_argument("-v", "--verbose", action="store_true",
     help="print per-rank detailed timing")
 parser.add_argument("--old-format", action="store_true",
     help="use old format for benchmark data filenames")
+parser.add_argument("--model", action="store_true", required=False, help="output 2D pixel model file")
 args = parser.parse_args()
 
 start_time = args.start_time
@@ -173,6 +174,10 @@ for camera in group_cameras:
         cmd = cmd + " -w 7520.0,9824.0,0.8"
 
     cmd = cmd + " --gpu-specter --nsubbundles 5"
+
+    if args.model:
+        model_filename = frame_filename.rstrip(".fits") + "-model.fits"
+        cmd = cmd + f" --model {model_filename}"
 
     if args.gpu:
         cmd = cmd + " --gpu"

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -139,7 +139,13 @@ def assemble_bundle_patches(rankresults):
         chi2pix[patch.specslice, patch.waveslice] = xchi2pix[:, patch.keepslice]
 
         patchmodel = result['modelimage']
-        if patchmodel is None or ~np.all(np.isfinite(patchmodel)):
+        #- Skip if patchmodel is None, an array of None, or contains any nans
+        skip_patchmodel = (
+            (patchmodel is None)
+            or (not patchmodel.any())
+            or (not np.all(np.isfinite(patchmodel)))
+        )
+        if skip_patchmodel:
             continue
         ymin = patch.xyslice[0].start - ystart
         xmin = patch.xyslice[1].start - xstart
@@ -332,7 +338,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
                     zip(patches,
                         map(lambda x: dict(
                                 flux=x[0], ivar=x[1], Rdiags=x[2],
-                                pixmask_fraction=x[3], chi2pix=x[4], modelimage=x[3]
+                                pixmask_fraction=x[3], chi2pix=x[4], modelimage=x[5]
                             ),
                             zip(
                                 flux, fluxivar, resolution, 

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -448,10 +448,16 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             else:
                 #- If only one rank per gpu, don't need bundle level communication
                 bundle_comm = None
+                bundle_rank = 0
         else:
             #- Single gpu, only do MPI communication at bundle level
             frame_comm = None
             bundle_comm = comm
+
+        frame_comm = comm
+        bundle_comm = None
+        bundle_rank = 0
+
     else:
         #- No gpu, do MPI communication at bundle level
         frame_comm = None
@@ -521,6 +527,9 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
     if frame_comm is None:
         bundle_start = 0
         bundle_step = 1
+    elif bundle_comm is None:
+        bundle_start = rank
+        bundle_step = size
     else:
         bundle_start = device_id
         bundle_step = device_count

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -234,9 +234,6 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             patches.append(patch)
         subbundles.append(patches)
 
-    # if rank == 0:
-    #     log.debug(f'Dividing {len(patches)} patches between {size} ranks')
-
     timer.split('organize patches')
 
     #- place to keep extraction patch results before assembling in rank 0

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -157,7 +157,7 @@ def assemble_bundle_patches(rankresults):
 
 def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=25, nsubbundles=1,
     nwavestep=50, wavepad=10, comm=None, gpu=None, loglevel=None, model=None, regularize=0,
-    psferr=None):
+    psferr=None, clip_scale=0):
     """
     Extract 1D spectra from a single bundle of a 2D image.
 
@@ -265,7 +265,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
             # perform batch extraction
             cp.cuda.nvtx.RangePush('batch_extraction')
             batch_flux, batch_fluxivar, batch_resolution = batch_extraction(
-                batch_pixels, batch_ivar, batch_A4, regularize=regularize, clip_scale=1e-4
+                batch_pixels, batch_ivar, batch_A4, regularize=regularize, clip_scale=clip_scale
             )
             cp.cuda.nvtx.RangePop()
 
@@ -393,7 +393,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
 
 
 def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavestep=50, nsubbundles=1,
-    model=None, regularize=0, psferr=None, comm=None, rank=0, size=1, gpu=None, loglevel=None, timing=None):
+    model=None, regularize=0, psferr=None, comm=None, rank=0, size=1, gpu=None, loglevel=None, timing=None, clip_scale=0):
     """
     Extract 1D spectra from 2D image.
 
@@ -542,6 +542,7 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             model=model,
             regularize=regularize,
             psferr=psferr,
+            clip_scale=clip_scale,
         )
         if gpu:
             cp.cuda.nvtx.RangePop()

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -10,6 +10,7 @@ import numpy as np
 import numpy.polynomial.legendre
 from numba import cuda
 import cupy as cp
+import cupyx
 import cupyx.scipy.special
 
 from .cpu import get_spec_padding
@@ -505,7 +506,6 @@ def batch_cholesky_solve(a, b):
 
     return b.conj().reshape(b_shape)
 
-import cupyx
 
 def batch_decorrelate(batch_icov, block_size, clip_scale=0):
 
@@ -523,6 +523,7 @@ def batch_decorrelate(batch_icov, block_size, clip_scale=0):
 
 
     cp.cuda.nvtx.RangePush('compose')
+    
     if clip_scale > 0:
         w = cp.clip(w, a_min=clip_scale*cp.max(w))
     cov = cp.einsum('...ik,...k,...jk->...ij', v, 1.0/w, v)

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -424,7 +424,7 @@ def apply_weights(pixel_values, pixel_ivar, A, regularize=0, weight_scale=1e-4):
         
     return icov, y
     
-def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scale=1e-4):
+def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scale=0):
 
     nbatches = len(batch_pixels)
 

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -475,7 +475,7 @@ def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scal
             Q[i, s:s + nwavetot, s:s + nwavetot] = q[i*nspecpad + j]
 
     s = cp.sum(Q, axis=-1)
-    batch_resolution = Q/s[:, cp.newaxis]
+    batch_resolution = Q/s[..., cp.newaxis]
     batch_fluxivar = (s**2).reshape(-1, nspecpad, nwavetot)
     batch_flux = cp.einsum('lij,lj->li', batch_resolution, deconvolved).reshape(-1, nspecpad, nwavetot)
     cp.cuda.nvtx.RangePop()

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -384,316 +384,6 @@ def get_resolution_diags(R, ndiag, ispec, nspec, nwave, wavepad):
         Rdiags[i-ispec] = R[ii, ii][:,wavepad:-wavepad].T[mask].reshape(nwave, 2*ndiag+1).T
     return Rdiags
 
-def prepare_patch(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, wavepad, bundlesize):
-    specmin, nspecpad = get_spec_padding(ispec, nspec, bundlesize)
-    nwavetot = nwave+2*wavepad
-    A4, xyrange = projection_matrix(specmin, nspecpad, iwave-wavepad, nwave+2*wavepad, spots, corners)
-    xmin, xmax, ypadmin, ypadmax = xyrange
-
-    xlo, xhi, ymin, ymax = get_xyrange(specmin, nspecpad, iwave, nwave, spots, corners)
-
-    ypadlo = ymin - ypadmin
-    ypadhi = ypadmax - ymax
-    A4 = A4[ypadlo:-ypadhi]
-
-    ny, nx = A4.shape[0:2]
-
-    if (0 <= ymin) & (ymin+ny <= image.shape[0]):
-        xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
-        patchpixels = image[xyslice]
-        patchivar = imageivar[xyslice]
-    else:
-        xyslice = None
-        patchivar = cp.zeros((ny, nx))
-        patchpixels = cp.zeros((ny, nx))
-
-    return patchpixels, patchivar, A4, xyslice
-
-def apply_weights(pixel_values, pixel_ivar, A, regularize=0, weight_scale=1e-4):
-    ATNinv = A.T * pixel_ivar
-    icov = ATNinv.dot(A)
-    y = ATNinv.dot(pixel_values)
-    fluxweight = ATNinv.sum(axis=1)
-
-    minweight = weight_scale*cp.max(fluxweight)
-    ibad = fluxweight <= minweight
-    lambda_squared = regularize*regularize*cp.ones_like(y)
-    lambda_squared[ibad] = minweight - fluxweight[ibad]
-    if np.any(lambda_squared):
-        icov += cp.diag(lambda_squared)
-
-    return icov, y
-
-def batch_apply_weights(batch_pixels, batch_ivar, batch_A4, regularize=0, weight_scale=1e-4):
-
-    batch_size = len(batch_A4)
-    ny, nx, nspecpad, nwavetot = batch_A4[0].shape
-    nbin = nspecpad * nwavetot
-
-    batch_icov = cp.zeros((batch_size, nbin, nbin))
-    batch_y = cp.zeros((batch_size, nbin))
-    for i, (pix, ivar, A4) in enumerate(zip(batch_pixels, batch_ivar, batch_A4)):
-        # Note that each patch can have a different number of pixels
-        batch_icov[i], batch_y[i] = apply_weights(
-            pix.ravel(), ivar.ravel(), A4.reshape(-1, nbin),
-            regularize=regularize, weight_scale=weight_scale)
-
-    return batch_icov, batch_y
-
-def batch_cholesky_solve(a, b):
-    """Solve the linear equations A x = b via Cholesky factorization of A, where A
-    is a real symmetric or complex Hermitian positive-definite matrix.
-
-    If matrix ``a[i]`` is not positive definite, Cholesky factorization fails and
-    it raises an error.
-
-    Args:
-        a (cupy.ndarray): Array of real symmetric or complex hermitian
-            matrices with dimension (..., N, N).
-        b (cupy.ndarray): right-hand side (..., N).
-    Returns:
-        x (cupy.ndarray): Array of solutions (..., N).
-    """
-    if not cp.cusolver.check_availability('potrsBatched'):
-        raise RuntimeError('potrsBatched is not available')
-
-    dtype = numpy.promote_types(a.dtype, b.dtype)
-    dtype = numpy.promote_types(dtype, 'f')
-
-    if dtype == 'f':
-        potrfBatched = cp.cuda.cusolver.spotrfBatched
-        potrsBatched = cp.cuda.cusolver.spotrsBatched
-    elif dtype == 'd':
-        potrfBatched = cp.cuda.cusolver.dpotrfBatched
-        potrsBatched = cp.cuda.cusolver.dpotrsBatched
-    elif dtype == 'F':
-        potrfBatched = cp.cuda.cusolver.cpotrfBatched
-        potrsBatched = cp.cuda.cusolver.cpotrsBatched
-    elif dtype == 'D':
-        potrfBatched = cp.cuda.cusolver.zpotrfBatched
-        potrsBatched = cp.cuda.cusolver.zpotrsBatched
-    else:
-        msg = ('dtype must be float32, float64, complex64 or complex128'
-               ' (actual: {})'.format(a.dtype))
-        raise ValueError(msg)
-
-    # Cholesky factorization
-    a = a.astype(dtype, order='C', copy=True)
-    ap = cp.core._mat_ptrs(a)
-    lda, n = a.shape[-2:]
-    batch_size = int(numpy.prod(a.shape[:-2]))
-
-    handle = cp.cuda.device.get_cusolver_handle()
-    uplo = cp.cuda.cublas.CUBLAS_FILL_MODE_LOWER
-    dev_info = cp.empty(batch_size, dtype=numpy.int32)
-
-    potrfBatched(handle, uplo, n, ap.data.ptr, lda, dev_info.data.ptr,
-                 batch_size)
-    cp.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-        potrfBatched, dev_info)
-
-    # Cholesky solve
-    b_shape = b.shape
-    b = b.conj().reshape(batch_size, n, -1).astype(dtype, order='C', copy=True)
-    bp = cp.core._mat_ptrs(b)
-    ldb, nrhs = b.shape[-2:]
-    dev_info = cp.empty(1, dtype=numpy.int32)
-
-    potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
-                 dev_info.data.ptr, batch_size)
-    cp.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-        potrsBatched, dev_info)
-
-    return b.conj().reshape(b_shape)
-
-
-def batch_decorrelate(batch_icov, block_size, clip_scale=0):
-
-    batch_size, n, m = batch_icov.shape
-    nblocks, remainder = divmod(n, block_size)
-    assert n == m
-    assert remainder == 0
-
-    cp.cuda.nvtx.RangePush('batch_invert_icov')
-    # invert icov
-    # cov = cp.linalg.inv(batch_icov)
-    cp.cuda.nvtx.RangePush('eigh')
-    w, v = cp.linalg.eigh(batch_icov)
-    cp.cuda.nvtx.RangePop() # eigh
-
-
-    cp.cuda.nvtx.RangePush('compose')
-    
-    if clip_scale > 0:
-        w = cp.clip(w, a_min=clip_scale*cp.max(w))
-    cov = cp.einsum('...ik,...k,...jk->...ij', v, 1.0/w, v)
-    cp.cuda.nvtx.RangePop() # compose
-    cp.cuda.nvtx.RangePop() # batch_invert_icov
-
-    cp.cuda.nvtx.RangePush('extract_blocks')
-    cov_block_diags = cp.empty(
-        (batch_size * nblocks, block_size, block_size),
-        dtype=batch_icov.dtype
-    )
-    for i in range(batch_size):
-        for j, s in enumerate(range(0, n, block_size)):
-            cov_block_diags[i*nblocks + j] = cov[i, s:s + block_size, s:s + block_size]
-    cp.cuda.nvtx.RangePop() # extract_blocks
-
-    cp.cuda.nvtx.RangePush('eigh')
-    ww, vv = cp.linalg.eigh(cov_block_diags)
-    cp.cuda.nvtx.RangePop() # eigh
-    cp.cuda.nvtx.RangePush('compose')
-    if clip_scale > 0:
-        ww = cp.clip(ww, a_min=clip_scale*cp.max(ww))
-    q = cp.einsum('...ik,...k,...jk->...ij', vv, cupyx.rsqrt(ww), vv)
-    cp.cuda.nvtx.RangePop() # compose
-
-    cp.cuda.nvtx.RangePush('replace_blocks')
-    Q = cp.zeros_like(batch_icov)
-    for i in range(batch_size):
-        for j, s in enumerate(range(0, n, block_size)):
-            Q[i, s:s + block_size, s:s + block_size] = q[i*nblocks + j]
-    cp.cuda.nvtx.RangePop() # replace_blocks
-
-    return Q
-
-def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scale=0):
-
-    batch_size = len(batch_A4)
-    ny, nx, nspecpad, nwavetot = batch_A4[0].shape
-
-    cp.cuda.nvtx.RangePush('apply_weights')
-    batch_icov, batch_y = batch_apply_weights(batch_pixels, batch_ivar, batch_A4, regularize=regularize)
-    cp.cuda.nvtx.RangePop() # apply_weights
-
-    cp.cuda.nvtx.RangePush('deconvolve')
-    deconvolved = batch_cholesky_solve(batch_icov, batch_y)
-    cp.cuda.nvtx.RangePop() # deconvolve
-
-    cp.cuda.nvtx.RangePush('decorrelate')
-    batch_Q = batch_decorrelate(batch_icov, nwavetot, clip_scale=clip_scale)
-
-    cp.cuda.nvtx.RangePush('apply_resolution')
-    s = cp.einsum('...ij->...i', batch_Q)
-    batch_resolution = batch_Q/s[..., cp.newaxis]
-    batch_fluxivar = (s*s).reshape(-1, nspecpad, nwavetot)
-    batch_flux = cp.einsum('...ij,...j->...i', batch_resolution, deconvolved).reshape(-1, nspecpad, nwavetot)
-    cp.cuda.nvtx.RangePop() # apply_resolution
-
-    cp.cuda.nvtx.RangePop() # decorrelate
-
-    return batch_flux, batch_fluxivar, batch_resolution
-
-def finalize_patch(patchpixels, patchivar, A4, xyslice, fx, ivarfx, R,
-    ispec, nspec, bundlesize, nwave, wavepad, ndiag, psferr, model=None):
-
-    specmin, nspecpad = get_spec_padding(ispec, nspec, bundlesize)
-
-    specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
-    specflux = fx[specslice]
-    specivar = ivarfx[specslice]
-    Rdiags = get_resolution_diags(R, ndiag, ispec-specmin, nspec, nwave, wavepad)
-
-    ny, nx, nspecpad, nwavetot = A4.shape
-
-    Apadded = A4.reshape(ny*nx, nspecpad*nwavetot)
-    Apatch = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave]
-    Apatch = Apatch.reshape(ny*nx, nspec*nwave)
-
-    pixmask_fraction = Apatch.T.dot(patchivar.ravel() == 0)
-    pixmask_fraction = pixmask_fraction.reshape(nspec, nwave)
-
-    modelpadded = Apadded.dot(fx.ravel()).reshape(ny, nx)
-    modelivar = (modelpadded*psferr + 1e-32)**-2
-    ii = (modelivar > 0 ) & (patchivar > 0)
-    totpix_ivar = cp.zeros((ny, nx))
-    totpix_ivar[ii] = 1.0 / (1.0/modelivar[ii] + 1.0/patchivar[ii])
-
-    #- Weighted chi2 of pixels that contribute to each flux bin;
-    #- only use unmasked pixels and avoid dividing by 0
-    chi = (patchpixels - modelpadded)*cp.sqrt(totpix_ivar)
-    psfweight = Apadded.T.dot(totpix_ivar.ravel() > 0)
-    bad = psfweight == 0
-
-    #- Compute chi2pix and reshape
-    chi2pix = (Apadded.T.dot(chi.ravel()**2) * ~bad) / (psfweight + bad)
-    chi2pix = chi2pix.reshape(nspecpad, nwavetot)[specslice]
-
-    if model:
-        modelimage = Apatch.dot(specflux.ravel()).reshape(ny, nx)
-    else:
-        #modelimage = cp.zeros((ny, nx))
-        modelimage = None
-
-    result = dict(
-        flux = specflux,
-        ivar = specivar,
-        Rdiags = Rdiags,
-        modelimage = modelimage,
-        xyslice = xyslice,
-        pixmask_fraction = pixmask_fraction,
-        chi2pix = chi2pix,
-    )
-
-    return result
-
-def ex2d_subbundle(image, imageivar, patches, spots, corners, bundlesize, regularize, clip_scale, psferr, model):
-    """Extract an entire subbundle of patches. The patches' output shape (nspec, nwave) must be aligned.
-
-    Args:
-        image: full image (not trimmed to a particular xy range)
-        imageivar: image inverse variance (same dimensions as image)
-        patches: list contain gpu_specter.core.Patch objects for extraction
-        spots: array[nspec, nwave, ny, nx] pre-evaluated PSF spots
-        corners: tuple of arrays xcorners[nspec, nwave], ycorners[nspec, nwave]
-        bundlesize: size of fiber bundles
-        clip_scale: scale factor to use when clipping eigenvalues
-        psferr: value of error to assume in psf model
-        model: compute image pixel model using extracted flux
-
-    Returns:
-        results: list of (patch, result) tuples
-    """
-    batch_pixels = list()
-    batch_ivar = list()
-    batch_A4 = list()
-    batch_xyslice = list()
-
-    cp.cuda.nvtx.RangePush('batch_prepare')
-    for patch in patches:
-        patchpixels, patchivar, patchA4, xyslice = prepare_patch(
-            image, imageivar, patch.ispec-patch.bspecmin, patch.nspectra_per_patch,
-            patch.iwave, patch.nwavestep, spots, corners, wavepad=patch.wavepad, bundlesize=bundlesize,
-        )
-        patch.xyslice = xyslice
-        batch_pixels.append(patchpixels)
-        batch_ivar.append(patchivar)
-        batch_A4.append(patchA4)
-        batch_xyslice.append(xyslice)
-    cp.cuda.nvtx.RangePop()
-
-    # perform batch extraction
-    cp.cuda.nvtx.RangePush('batch_extraction')
-    batch_flux, batch_fluxivar, batch_resolution = batch_extraction(
-        batch_pixels, batch_ivar, batch_A4, regularize=regularize, clip_scale=clip_scale
-    )
-    cp.cuda.nvtx.RangePop()
-
-    # finalize patch results
-    cp.cuda.nvtx.RangePush('batch_finalize')
-    results = list()
-    for i, patch in enumerate(patches):
-        result = finalize_patch(
-            batch_pixels[i], batch_ivar[i], batch_A4[i], batch_xyslice[i],
-            batch_flux[i], batch_fluxivar[i], batch_resolution[i],
-            patch.ispec-patch.bspecmin, patch.nspectra_per_patch, bundlesize,
-            patch.nwavestep, patch.wavepad, patch.ndiag, psferr, model=model
-        )
-        results.append( (patches[i], result) )
-    cp.cuda.nvtx.RangePop()
-
-    return results
 
 def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, psferr,
                 wavepad, bundlesize=25, model=None, regularize=0):
@@ -841,3 +531,333 @@ def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, ps
     # timer.print_splits()
 
     return result
+
+
+def _prepare_patch(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, wavepad, bundlesize):
+    specmin, nspecpad = get_spec_padding(ispec, nspec, bundlesize)
+    nwavetot = nwave+2*wavepad
+    A4, xyrange = projection_matrix(specmin, nspecpad, iwave-wavepad, nwave+2*wavepad, spots, corners)
+    xmin, xmax, ypadmin, ypadmax = xyrange
+
+    xlo, xhi, ymin, ymax = get_xyrange(specmin, nspecpad, iwave, nwave, spots, corners)
+
+    ypadlo = ymin - ypadmin
+    ypadhi = ypadmax - ymax
+    A4 = A4[ypadlo:-ypadhi]
+
+    ny, nx = A4.shape[0:2]
+
+    if (0 <= ymin) & (ymin+ny <= image.shape[0]):
+        xyslice = np.s_[ymin:ymin+ny, xmin:xmin+nx]
+        patchpixels = image[xyslice]
+        patchivar = imageivar[xyslice]
+    else:
+        xyslice = None
+        patchivar = cp.zeros((ny, nx))
+        patchpixels = cp.zeros((ny, nx))
+
+    return patchpixels, patchivar, A4, xyslice
+
+def _apply_weights(pixel_values, pixel_ivar, A, regularize=0, weight_scale=1e-4):
+    ATNinv = A.T * pixel_ivar
+    icov = ATNinv.dot(A)
+    y = ATNinv.dot(pixel_values)
+    fluxweight = ATNinv.sum(axis=1)
+
+    minweight = weight_scale*cp.max(fluxweight)
+    ibad = fluxweight <= minweight
+    lambda_squared = regularize*regularize*cp.ones_like(y)
+    lambda_squared[ibad] = minweight - fluxweight[ibad]
+    if np.any(lambda_squared):
+        icov += cp.diag(lambda_squared)
+
+    return icov, y
+
+def _batch_apply_weights(batch_pixels, batch_ivar, batch_A4, regularize=0, weight_scale=1e-4):
+
+    batch_size = len(batch_A4)
+    ny, nx, nspecpad, nwavetot = batch_A4[0].shape
+    nbin = nspecpad * nwavetot
+
+    batch_icov = cp.zeros((batch_size, nbin, nbin))
+    batch_y = cp.zeros((batch_size, nbin))
+    for i, (pix, ivar, A4) in enumerate(zip(batch_pixels, batch_ivar, batch_A4)):
+        # Note that each patch can have a different number of pixels
+        batch_icov[i], batch_y[i] = _apply_weights(
+            pix.ravel(), ivar.ravel(), A4.reshape(-1, nbin),
+            regularize=regularize, weight_scale=weight_scale)
+
+    return batch_icov, batch_y
+
+def _batch_cholesky_solve(a, b):
+    """Solve the linear equations A x = b via Cholesky factorization of A, where A
+    is a real symmetric or complex Hermitian positive-definite matrix.
+
+    If matrix ``a[i]`` is not positive definite, Cholesky factorization fails and
+    it raises an error.
+
+    Args:
+        a (cupy.ndarray): Array of real symmetric or complex hermitian
+            matrices with dimension (..., N, N).
+        b (cupy.ndarray): right-hand side (..., N).
+    Returns:
+        x (cupy.ndarray): Array of solutions (..., N).
+    """
+    if not cp.cusolver.check_availability('potrsBatched'):
+        raise RuntimeError('potrsBatched is not available')
+
+    dtype = numpy.promote_types(a.dtype, b.dtype)
+    dtype = numpy.promote_types(dtype, 'f')
+
+    if dtype == 'f':
+        potrfBatched = cp.cuda.cusolver.spotrfBatched
+        potrsBatched = cp.cuda.cusolver.spotrsBatched
+    elif dtype == 'd':
+        potrfBatched = cp.cuda.cusolver.dpotrfBatched
+        potrsBatched = cp.cuda.cusolver.dpotrsBatched
+    elif dtype == 'F':
+        potrfBatched = cp.cuda.cusolver.cpotrfBatched
+        potrsBatched = cp.cuda.cusolver.cpotrsBatched
+    elif dtype == 'D':
+        potrfBatched = cp.cuda.cusolver.zpotrfBatched
+        potrsBatched = cp.cuda.cusolver.zpotrsBatched
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(a.dtype))
+        raise ValueError(msg)
+
+    # Cholesky factorization
+    a = a.astype(dtype, order='C', copy=True)
+    ap = cp.core._mat_ptrs(a)
+    lda, n = a.shape[-2:]
+    batch_size = int(numpy.prod(a.shape[:-2]))
+
+    handle = cp.cuda.device.get_cusolver_handle()
+    uplo = cp.cuda.cublas.CUBLAS_FILL_MODE_LOWER
+    dev_info = cp.empty(batch_size, dtype=numpy.int32)
+
+    potrfBatched(handle, uplo, n, ap.data.ptr, lda, dev_info.data.ptr,
+                 batch_size)
+    cp.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrfBatched, dev_info)
+
+    # Cholesky solve
+    b_shape = b.shape
+    b = b.conj().reshape(batch_size, n, -1).astype(dtype, order='C', copy=True)
+    bp = cp.core._mat_ptrs(b)
+    ldb, nrhs = b.shape[-2:]
+    dev_info = cp.empty(1, dtype=numpy.int32)
+
+    potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
+                 dev_info.data.ptr, batch_size)
+    cp.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrsBatched, dev_info)
+
+    return b.conj().reshape(b_shape)
+
+def _batch_decorrelate_noise(icov):
+    cp.cuda.nvtx.RangePush('batch_sqrt_icov')
+    cp.cuda.nvtx.RangePush('eigh')
+    w, v = xp.linalg.eigh(iCov)
+    cp.cuda.nvtx.RangePop() # eigh
+    cp.cuda.nvtx.RangePush('compose')
+    Q = cp.einsum('...ik,...k,...jk->...ij', v, cp.sqrt(w), v)
+    cp.cuda.nvtx.RangePop() # compose
+    cp.cuda.nvtx.RangePop() # batch_sqrt_icov
+    return Q
+
+
+def _batch_decorrelate(icov, block_size, clip_scale=0):
+
+    batch_size, n, m = icov.shape
+    nblocks, remainder = divmod(n, block_size)
+    assert n == m
+    assert remainder == 0
+
+    cp.cuda.nvtx.RangePush('batch_invert_icov')
+    # invert icov
+    # cov = cp.linalg.inv(icov)
+    cp.cuda.nvtx.RangePush('eigh')
+    w, v = cp.linalg.eigh(icov)
+    cp.cuda.nvtx.RangePop() # eigh
+
+    cp.cuda.nvtx.RangePush('compose')
+    if clip_scale > 0:
+        w = cp.clip(w, a_min=clip_scale*cp.max(w))
+    cov = cp.einsum('...ik,...k,...jk->...ij', v, 1.0/w, v)
+    cp.cuda.nvtx.RangePop() # compose
+    cp.cuda.nvtx.RangePop() # batch_invert_icov
+
+    cp.cuda.nvtx.RangePush('extract_blocks')
+    cov_block_diags = cp.empty(
+        (batch_size * nblocks, block_size, block_size),
+        dtype=icov.dtype
+    )
+    for i in range(batch_size):
+        for j, s in enumerate(range(0, n, block_size)):
+            cov_block_diags[i*nblocks + j] = cov[i, s:s + block_size, s:s + block_size]
+    cp.cuda.nvtx.RangePop() # extract_blocks
+
+    cp.cuda.nvtx.RangePush('eigh')
+    ww, vv = cp.linalg.eigh(cov_block_diags)
+    cp.cuda.nvtx.RangePop() # eigh
+
+    cp.cuda.nvtx.RangePush('compose')
+    if clip_scale > 0:
+        ww = cp.clip(ww, a_min=clip_scale*cp.max(ww))
+    q = cp.einsum('...ik,...k,...jk->...ij', vv, cupyx.rsqrt(ww), vv)
+    cp.cuda.nvtx.RangePop() # compose
+
+    cp.cuda.nvtx.RangePush('replace_blocks')
+    Q = cp.zeros_like(icov)
+    for i in range(batch_size):
+        for j, s in enumerate(range(0, n, block_size)):
+            Q[i, s:s + block_size, s:s + block_size] = q[i*nblocks + j]
+    cp.cuda.nvtx.RangePop() # replace_blocks
+
+    return Q
+
+
+def _batch_apply_resolution(deconvolved, Q):
+    s = cp.einsum('...ij->...i', Q)
+    resolution = Q/s[..., cp.newaxis]
+    fluxivar = s*s
+    flux = cp.einsum('...ij,...j->...i', resolution, deconvolved)
+    return flux, fluxivar, resolution
+
+
+def _batch_extraction(pixel_values, pixel_ivar, A4, regularize=0, clip_scale=0):
+
+    batch_size = len(A4)
+    ny, nx, nspecpad, nwavetot = A4[0].shape
+
+    cp.cuda.nvtx.RangePush('apply_weights')
+    icov, y = _batch_apply_weights(pixel_values, pixel_ivar, A4, regularize=regularize)
+    cp.cuda.nvtx.RangePop() # apply_weights
+
+    cp.cuda.nvtx.RangePush('deconvolve')
+    deconvolved = _batch_cholesky_solve(icov, y)
+    cp.cuda.nvtx.RangePop() # deconvolve
+
+    cp.cuda.nvtx.RangePush('decorrelate')
+    Q = _batch_decorrelate(icov, nwavetot, clip_scale=clip_scale)
+    # Q = _batch_decorrelate_noise(icov)
+    cp.cuda.nvtx.RangePop() # decorrelate
+
+    cp.cuda.nvtx.RangePush('apply_resolution')
+    flux, fluxivar, resolution = _batch_apply_resolution(deconvolved, Q)
+    cp.cuda.nvtx.RangePop() # apply_resolution
+
+    return flux, fluxivar, resolution
+
+def _finalize_patch(patchpixels, patchivar, A4, xyslice, fx, ivarfx, R,
+    ispec, nspec, bundlesize, nwave, wavepad, ndiag, psferr, model=None):
+
+    specmin, nspecpad = get_spec_padding(ispec, nspec, bundlesize)
+
+    ny, nx, nspecpad, nwavetot = A4.shape
+
+    specslice = np.s_[ispec-specmin:ispec-specmin+nspec,wavepad:wavepad+nwave]
+    specflux = fx.reshape(nspecpad, nwavetot)[specslice]
+    specivar = ivarfx.reshape(nspecpad, nwavetot)[specslice]
+    Rdiags = get_resolution_diags(R, ndiag, ispec-specmin, nspec, nwave, wavepad)
+
+    Apadded = A4.reshape(ny*nx, nspecpad*nwavetot)
+    Apatch = A4[:, :, ispec-specmin:ispec-specmin+nspec, wavepad:wavepad+nwave]
+    Apatch = Apatch.reshape(ny*nx, nspec*nwave)
+
+    pixmask_fraction = Apatch.T.dot(patchivar.ravel() == 0)
+    pixmask_fraction = pixmask_fraction.reshape(nspec, nwave)
+
+    modelpadded = Apadded.dot(fx.ravel()).reshape(ny, nx)
+    modelivar = (modelpadded*psferr + 1e-32)**-2
+    ii = (modelivar > 0 ) & (patchivar > 0)
+    totpix_ivar = cp.zeros((ny, nx))
+    totpix_ivar[ii] = 1.0 / (1.0/modelivar[ii] + 1.0/patchivar[ii])
+
+    #- Weighted chi2 of pixels that contribute to each flux bin;
+    #- only use unmasked pixels and avoid dividing by 0
+    chi = (patchpixels - modelpadded)*cp.sqrt(totpix_ivar)
+    psfweight = Apadded.T.dot(totpix_ivar.ravel() > 0)
+    bad = psfweight == 0
+
+    #- Compute chi2pix and reshape
+    chi2pix = (Apadded.T.dot(chi.ravel()**2) * ~bad) / (psfweight + bad)
+    chi2pix = chi2pix.reshape(nspecpad, nwavetot)[specslice]
+
+    if model:
+        modelimage = Apatch.dot(specflux.ravel()).reshape(ny, nx)
+    else:
+        #modelimage = cp.zeros((ny, nx))
+        modelimage = None
+
+    result = dict(
+        flux = specflux,
+        ivar = specivar,
+        Rdiags = Rdiags,
+        modelimage = modelimage,
+        xyslice = xyslice,
+        pixmask_fraction = pixmask_fraction,
+        chi2pix = chi2pix,
+    )
+
+    return result
+
+def ex2d_subbundle(image, imageivar, patches, spots, corners, bundlesize, regularize, clip_scale, psferr, model):
+    """Extract an entire subbundle of patches. The patches' output shape (nspec, nwave) must be aligned.
+
+    Args:
+        image: full image (not trimmed to a particular xy range)
+        imageivar: image inverse variance (same dimensions as image)
+        patches: list contain gpu_specter.core.Patch objects for extraction
+        spots: array[nspec, nwave, ny, nx] pre-evaluated PSF spots
+        corners: tuple of arrays xcorners[nspec, nwave], ycorners[nspec, nwave]
+        bundlesize: size of fiber bundles
+        clip_scale: scale factor to use when clipping eigenvalues
+        psferr: value of error to assume in psf model
+        model: compute image pixel model using extracted flux
+
+    Returns:
+        results: list of (patch, result) tuples
+    """
+    batch_pixels = list()
+    batch_ivar = list()
+    batch_A4 = list()
+    batch_xyslice = list()
+
+    cp.cuda.nvtx.RangePush('batch_prepare')
+    for patch in patches:
+        patchpixels, patchivar, patchA4, xyslice = _prepare_patch(
+            image, imageivar, patch.ispec-patch.bspecmin, patch.nspectra_per_patch,
+            patch.iwave, patch.nwavestep, spots, corners, wavepad=patch.wavepad, bundlesize=bundlesize,
+        )
+        patch.xyslice = xyslice
+        batch_pixels.append(patchpixels)
+        batch_ivar.append(patchivar)
+        batch_A4.append(patchA4)
+        batch_xyslice.append(xyslice)
+    cp.cuda.nvtx.RangePop()
+
+    # perform batch extraction
+    cp.cuda.nvtx.RangePush('batch_extraction')
+    batch_flux, batch_fluxivar, batch_resolution = _batch_extraction(
+        batch_pixels, batch_ivar, batch_A4, regularize=regularize, clip_scale=clip_scale
+    )
+    cp.cuda.nvtx.RangePop()
+
+    # finalize patch results
+    cp.cuda.nvtx.RangePush('batch_finalize')
+    results = list()
+    for i, patch in enumerate(patches):
+        result = _finalize_patch(
+            batch_pixels[i], batch_ivar[i], batch_A4[i], batch_xyslice[i],
+            batch_flux[i], batch_fluxivar[i], batch_resolution[i],
+            patch.ispec-patch.bspecmin, patch.nspectra_per_patch, bundlesize,
+            patch.nwavestep, patch.wavepad, patch.ndiag, psferr, model=model
+        )
+        results.append( (patches[i], result) )
+    cp.cuda.nvtx.RangePop()
+
+    return results
+
+

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -12,11 +12,6 @@ import cupyx.scipy.special
 from numba import cuda
 
 import cupy
-from cupy.cuda import cublas
-from cupy.cuda import cusolver
-from cupy.cuda import device
-from cupy.cusolver import check_availability
-from cupy.linalg import _util
 
 from ..io import native_endian
 from ..util import Timer
@@ -431,9 +426,9 @@ def apply_weights(pixel_values, pixel_ivar, A, regularize=0, weight_scale=1e-4):
         
     return icov, y
 
-def batch_cho_solve(a, b):
+def batch_cholesky_solve(a, b):
     """Solve the linear equations A x = b via Cholesky factorization of A, where A
-    is a real symmetric or complex hermitian positive-definite matrix.
+    is a real symmetric or complex Hermitian positive-definite matrix.
 
     If matrix ``a[i]`` is not positive definite, Cholesky factorization fails and
     it raises an error.
@@ -443,67 +438,59 @@ def batch_cho_solve(a, b):
             matrices with dimension (..., N, N).
         b (cupy.ndarray): right-hand side (..., N).
     Returns:
-        x (cupy.ndarray): The array of solutions ``x[i]``.
+        x (cupy.ndarray): Array of solutions (..., N).
     """
-    if not check_availability('potrsBatched'):
+    if not cp.cusolver.check_availability('potrsBatched'):
         raise RuntimeError('potrsBatched is not available')
 
-    if a.dtype.char == 'f' or a.dtype.char == 'd':
-        dtype = a.dtype.char
-    else:
-        dtype = numpy.promote_types(a.dtype.char, 'f').char
+    dtype = numpy.promote_types(a.dtype, b.dtype)
+    dtype = numpy.promote_types(dtype, 'f')
 
     if dtype == 'f':
-        potrfBatched = cusolver.spotrfBatched
-        potrsBatched = cusolver.spotrsBatched
+        potrfBatched = cp.cuda.cusolver.spotrfBatched
+        potrsBatched = cp.cuda.cusolver.spotrsBatched
     elif dtype == 'd':
-        potrfBatched = cusolver.dpotrfBatched
-        potrsBatched = cusolver.dpotrsBatched
+        potrfBatched = cp.cuda.cusolver.dpotrfBatched
+        potrsBatched = cp.cuda.cusolver.dpotrsBatched
     elif dtype == 'F':
-        potrfBatched = cusolver.cpotrfBatched
-        potrsBatched = cusolver.cpotrsBatched
+        potrfBatched = cp.cuda.cusolver.cpotrfBatched
+        potrsBatched = cp.cuda.cusolver.cpotrsBatched
     elif dtype == 'D':
-        potrfBatched = cusolver.zpotrfBatched
-        potrsBatched = cusolver.zpotrsBatched
+        potrfBatched = cp.cuda.cusolver.zpotrfBatched
+        potrsBatched = cp.cuda.cusolver.zpotrsBatched
     else:
         msg = ('dtype must be float32, float64, complex64 or complex128'
                ' (actual: {})'.format(a.dtype))
         raise ValueError(msg)
 
-    a = a.astype(dtype, order='C', copy=True)
-    ap = cupy.core._mat_ptrs(a)
-    n = a.shape[-1]
-    lda = a.strides[-2] // a.dtype.itemsize
-    handle = device.get_cusolver_handle()
-    uplo = cublas.CUBLAS_FILL_MODE_LOWER
-    batch_size = int(numpy.prod(a.shape[:-2]))
-    dev_info = cupy.empty(batch_size, dtype=numpy.int32)
-
     # Cholesky factorization
+    a = a.astype(dtype, order='C', copy=True)
+    ap = cp.core._mat_ptrs(a)
+    lda, n = a.shape[-2:]
+    batch_size = int(numpy.prod(a.shape[:-2]))
+
+    handle = cp.cuda.device.get_cusolver_handle()
+    uplo = cp.cuda.cublas.CUBLAS_FILL_MODE_LOWER
+    dev_info = cp.empty(batch_size, dtype=numpy.int32)
+
     potrfBatched(handle, uplo, n, ap.data.ptr, lda, dev_info.data.ptr,
                  batch_size)
-    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+    cp.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
         potrfBatched, dev_info)
 
-    # identity_matrix = cupy.eye(n, dtype=dtype)
-    # b = cupy.empty(a.shape, dtype)
-    # b[...] = identity_matrix
+    # Cholesky solve
+    b_shape = b.shape
+    b = b.conj().reshape(batch_size, n, -1).astype(dtype, order='C', copy=True)
+    bp = cp.core._mat_ptrs(b)
+    ldb, nrhs = b.shape[-2:]
+    dev_info = cp.empty(1, dtype=numpy.int32)
 
-    bx = b.reshape(batch_size, n, 1).copy()
-
-    nrhs = bx.shape[-1]
-    ldb = bx.strides[0] // a.dtype.itemsize
-    bp = cupy.core._mat_ptrs(bx)
-    dev_info = cupy.empty(1, dtype=numpy.int32)
-
-    # NOTE: potrsBatched does not currently support nrhs > 1 (CUDA v10.2)
-    # Solve: A[i] * X[i] = B[i]
     potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
                  dev_info.data.ptr, batch_size)
-    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-        potrfBatched, dev_info)
+    cp.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrsBatched, dev_info)
 
-    return bx.reshape(batch_size, n)
+    return b.conj().reshape(b_shape)
     
 def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scale=0):
 
@@ -524,7 +511,7 @@ def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scal
     cp.cuda.nvtx.RangePush('batch_solve')
     # deconvolved = cp.linalg.solve(batch_icov, batch_y)
     # Use batch cholesky decomposition solve
-    deconvolved = batch_cho_solve(batch_icov, batch_y)
+    deconvolved = batch_cholesky_solve(batch_icov, batch_y)
     cp.cuda.nvtx.RangePop()
 
     cp.cuda.nvtx.RangePush('batch_invert_icov')
@@ -538,6 +525,7 @@ def batch_extraction(batch_pixels, batch_ivar, batch_A4, regularize=0, clip_scal
     vwinv = v * 1.0/w[:, np.newaxis, :]
     vt = v.transpose(0, 2, 1)
     cov = cp.einsum('lij,ljk->lik', vwinv, vt)
+    # cov = cp.einsum('...ik,...k,...jk->...ij', v, 1.0/w, v)
     cp.cuda.nvtx.RangePop()
 
     cp.cuda.nvtx.RangePush('batch_decorrelate')


### PR DESCRIPTION
This PR attempts to leverage more batch operations on the GPU by refactoring the extraction of individual patches into a stack of patches. It's a little tricky because the patches on the ccd do not have the same shape. The patches do stack cleanly once the projection and weight matrices are applied, so the heavy linear algebra operations (solve and eigh) can be performed in batch. 

The tables below shows before and after results using the 30 frame exposure extract script using a single node with 4 GPUs and 2 MPI ranks per GPU on corigpu (5 MPI ranks per GPU on dgx).

Before:

|system|elapsed time (sec)| FPNH | FPGH |
|-------|-------| ------- | ------- |
|corigpu|876.9|123.16|30.79|
|dgx|618.6|174.60|43.65|

This PR:

|system|elapsed time (sec)| FPNH | FPGH |
|-------|-------| ------- | ------- |
|corigpu|399.3|270.45|67.61|
|dgx|246.7|437.85|109.46|
