### PR TITLE
Extract patches that partially extend beyond range of image.

### DIFF
--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -60,47 +60,64 @@ parser.add_argument("--spex", action="store_true",
     help="use spex")
 parser.add_argument("--async-io", action="store_true",
     help="use fancy comm")
+parser.add_argument("--no-mpi", action="store_true",
+    help="don't use mpi")
 args = parser.parse_args()
 
 start_time = args.start_time
 
-from mpi4py import MPI
-
-comm = MPI.COMM_WORLD
-rank = comm.rank
-size = comm.size
+if args.no_mpi:
+    comm = None
+    rank, size = 0, 1
+    startup_waiting_time = time.time()
+    startup_time = time.time()
+else:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+    rank = comm.rank
+    size = comm.size
 
 startup_waiting_time = time.time()
-comm.barrier()
+if comm is not None:
+    comm.barrier()
 startup_time = time.time()
 
 #- Divide MPI ranks into per node communication groups
-node = MPI.Get_processor_name()
+if comm is not None:
+    node = MPI.Get_processor_name()
+else:
+    import socket
+    node = socket.gethostname()
 
 group = node
 if args.gpu:
     gpus = os.environ.get("CUDA_VISIBLE_DEVICES", "")
     group += ":" + gpus
 
-groups = comm.allgather(group)
-ngroups = len(set(groups))
-group_size = size // ngroups
+if comm is not None:
+    groups = comm.allgather(group)
+    ngroups = len(set(groups))
+    group_size = size // ngroups
 
-assert group_size * ngroups == size, \
-    f"Number of ranks {size} not divisible by number of groups {ngroups}"
+    assert group_size * ngroups == size, \
+        f"Number of ranks {size} not divisible by number of groups {ngroups}"
 
-#- Assumes contiguous blocks of MPI ranks per group
-group_rank = rank % group_size
-group_index = rank // group_size
-group_comm = comm.Split(color=group_index, key=group_rank)
+    #- Assumes contiguous blocks of MPI ranks per group
+    group_rank = rank % group_size
+    group_index = rank // group_size
+    group_comm = comm.Split(color=group_index, key=group_rank)
 
-if args.async_io:
-    group_comm = AsyncIOComm(group_comm)
+    if args.async_io:
+        group_comm = AsyncIOComm(group_comm)
+    else:
+        group_comm = SyncIOComm(group_comm)
 else:
-    group_comm = SyncIOComm(group_comm)
-
-# if not args.spex:
-#     group_comm = group_comm.extract_comm
+    ngroups = 1
+    group_index = 0
+    group_rank = 0
+    group_size = 1
+    group_comm = None
+    groups = [group, ]
 
 if rank == 0:
     print(f"Splitting {size} ranks into {ngroups} groups of {group_size}")
@@ -166,12 +183,12 @@ for camera in group_cameras:
 
     if not os.path.isfile(img_filename):
         if group_rank == 0:
-            print("Skipping {camera}, image file does not exist: {img_filename}")
+            print(f"Skipping {camera}, image file does not exist: {img_filename}")
             sys.stdout.flush()
         continue
     if not os.path.isfile(psf_filename):
         if group_rank == 0:
-            print("Skipping {camera}, psf file does not exist: {psf_filename}")
+            print(f"Skipping {camera}, psf file does not exist: {psf_filename}")
             sys.stdout.flush()
         continue
 
@@ -182,18 +199,21 @@ for camera in group_cameras:
         cmd = "desi_extract_spectra --gpu-specter"
         engine = extract
 
-    cmd += " --mpi" \
+    if not args.no_mpi:
+        cmd += " --mpi"
+
+    cmd += \
         f" -i {img_filename}" \
         f" -p {psf_filename}" \
         f" -o {frame_filename}"
 
     #- DEBUG speed
     # if camera.startswith("b"):
-    #     cmd = cmd + " -w 4000,4200,1"
+    #     cmd = cmd + " -w 3600.0,3700.0,0.8"
     # elif camera.startswith("r"):
-    #     cmd = cmd + " -w 6000,6200,1"
+    #     cmd = cmd + " -w 5760.0,5860.0,0.8"
     # elif camera.startswith("z"):
-    #     cmd = cmd + " -w 9000,9200,1"
+    #     cmd = cmd + " -w 7520.0,7620.0,0.8"
 
     if camera.startswith("b"):
         cmd = cmd + " -w 3600.0,5800.0,0.8"
@@ -216,7 +236,7 @@ for camera in group_cameras:
     if args.gpu:
         cmd = cmd + " --gpu"
 
-    if group_comm.rank == 0:
+    if group_rank == 0:
         print(rank, cmd)
         sys.stdout.flush()
 
@@ -234,20 +254,26 @@ for camera in group_cameras:
         events.append((group, rank, group_rank, camera, event_name, event_time - start_time))
 
     #- Mark successfully extracted frame
-    if group_comm.rank == 0:
+    if group_rank == 0:
         frames_extracted.append(camera)
 
 #- Wait for all ranks
 end_waiting_time = time.time()
-comm.barrier()
+if comm is not None:
+    comm.barrier()
 end_time = time.time()
 events.append((group, rank, group_rank, None, "exposure-end-waiting", end_waiting_time - start_time))
 events.append((group, rank, group_rank, None, "exposure-end", end_time - start_time))
 
 #- Collect metrics
-nframes = comm.reduce(len(frames_extracted), root=0)
-events = comm.gather(events, root=0)
-nodes = comm.gather(node, root=0)
+if comm is not None:
+    nframes = comm.reduce(len(frames_extracted), root=0)
+    events = comm.gather(events, root=0)
+    nodes = comm.gather(node, root=0)
+else:
+    nframes = len(frames_extracted)
+    events = [events, ]
+    nodes = [node, ]
 
 if rank == 0:
 

--- a/py/gpu_specter/extract/cpu.py
+++ b/py/gpu_specter/extract/cpu.py
@@ -222,7 +222,7 @@ def get_spots(specmin, nspec, wavelengths, psfdata):
 
     corners = (xc, yc)
 
-    return spots, corners
+    return spots, corners, p
 
 @numba.jit
 def get_xyrange(ispec, nspec, iwave, nwave, spots, corners):
@@ -344,7 +344,7 @@ def get_resolution_diags(R, ndiag, ispec, nspec, nwave, wavepad):
     return Rdiags
 
 def ex2d_padded(image, imageivar, ispec, nspec, iwave, nwave, spots, corners, psferr,
-                wavepad, bundlesize=25, model=None, regularize=0):
+                wavepad, bundlesize=25, model=None, regularize=0, patch=None):
     """
     Extracted a patch with border padding, but only return results for patch
 

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -502,7 +502,7 @@ def _prepare_patch(image, imageivar, specmin, nspectot, iwave, nwave, wavepad, s
     else:
         #- TODO: this zeros out the entire patch if any of it is off the edge
         #- of the image; we can do better than that
-        print('offedge:', ymin, ymin+ny, image.shape[0], flush=True)
+        #print('offedge:', ymin, ymin+ny, image.shape[0], flush=True)
         xyslice = None
         patchivar = cp.zeros((ny, nx))
         patchpixels = cp.zeros((ny, nx))
@@ -834,16 +834,16 @@ def _finalize_patch(patchpixels, patchivar, A4, xyslice, fx, ivarfx, R,
     #- Diagonals of R in a form suited for creating scipy.sparse.dia_matrix
     Rdiags = get_resolution_diags(R, ndiag, nspectot, nwave, wavepad)[specslice[0]]
 
-    if cp.any(cp.isnan(specflux[:, patch.keepslice])):
-        # raise RuntimeError('Found NaN in extracted flux')
-        print(f'nanflux: {patch.bspecmin}, {patch.ispec}, {patch.iwave}, {xyslice}', flush=True)
+    # if cp.any(cp.isnan(specflux[:, patch.keepslice])):
+    #     # raise RuntimeError('Found NaN in extracted flux')
+    #     print(f'nanflux: {patch.bspecmin}, {patch.ispec}, {patch.iwave}, {xyslice}', flush=True)
 
-    if cp.any(specflux[:, patch.keepslice] == 0):
-        # raise RuntimeError('Found zero in extracted flux')
-        print(specflux.shape, patch.keepslice, flush=True)
-        print(f'zeroflux: ({patch.bspecmin}, {patch.ispec}, {ispec}), {patch.iwave}, {xyslice}', flush=True)
-        where = np.where(specflux[:, patch.keepslice] == 0)
-        print(f'where: {where}', flush=True)
+    # if cp.any(specflux[:, patch.keepslice] == 0):
+    #     # raise RuntimeError('Found zero in extracted flux')
+    #     print(specflux.shape, patch.keepslice, flush=True)
+    #     print(f'zeroflux: ({patch.bspecmin}, {patch.ispec}, {ispec}), {patch.iwave}, {xyslice}', flush=True)
+    #     where = np.where(specflux[:, patch.keepslice] == 0)
+    #     print(f'where: {where}', flush=True)
 
     patchpixels = patchpixels.ravel()
     patchivar = patchivar.ravel()

--- a/py/gpu_specter/io.py
+++ b/py/gpu_specter/io.py
@@ -61,8 +61,9 @@ def read_img(filename):
         imgdata['image'] = native_endian(fx['IMAGE'].read().astype('f8'))
         imgdata['ivar'] = native_endian(fx['IVAR'].read().astype('f8'))
         imgdata['imagehdr'] = fx['IMAGE'].read_header()
-        mask = fx['MASK'].read()
-        imgdata['ivar'][mask != 0] = 0.0
+        imgdata['mask'] = fx['MASK'].read()
+        imgdata['ivar'][imgdata['mask'] != 0] = 0.0
+        # imgdata['image'] = imgdata['image']*(imgdata['ivar'] > 0)
         imgdata['fibermap'] = fx['FIBERMAP'].read()
         try:
             imgdata['fibermaphdr'] = fx['FIBERMAP'].read_header()

--- a/py/gpu_specter/linalg.py
+++ b/py/gpu_specter/linalg.py
@@ -1,0 +1,211 @@
+import numpy
+import cupy
+import cupy.prof
+import cupyx
+
+
+@cupy.prof.TimeRangeDecorator("_batch_posv")
+def _batch_posv(a, b):
+    """Solve the linear equations A x = b via Cholesky factorization of A, where A
+    is a real symmetric or complex Hermitian positive-definite matrix.
+
+    If matrix ``a[i]`` is not positive definite, Cholesky factorization fails and
+    it raises an error.
+
+    Args:
+        a (cupy.ndarray): Array of real symmetric or complex hermitian
+            matrices with dimension (..., N, N).
+        b (cupy.ndarray): right-hand side (..., N).
+    Returns:
+        x (cupy.ndarray): Array of solutions (..., N).
+    """
+    if not cupy.cusolver.check_availability('potrsBatched'):
+        raise RuntimeError('potrsBatched is not available')
+
+    dtype = numpy.promote_types(a.dtype, b.dtype)
+    dtype = numpy.promote_types(dtype, 'f')
+
+    if dtype == 'f':
+        potrfBatched = cupy.cuda.cusolver.spotrfBatched
+        potrsBatched = cupy.cuda.cusolver.spotrsBatched
+    elif dtype == 'd':
+        potrfBatched = cupy.cuda.cusolver.dpotrfBatched
+        potrsBatched = cupy.cuda.cusolver.dpotrsBatched
+    elif dtype == 'F':
+        potrfBatched = cupy.cuda.cusolver.cpotrfBatched
+        potrsBatched = cupy.cuda.cusolver.cpotrsBatched
+    elif dtype == 'D':
+        potrfBatched = cupy.cuda.cusolver.zpotrfBatched
+        potrsBatched = cupy.cuda.cusolver.zpotrsBatched
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(a.dtype))
+        raise ValueError(msg)
+
+    # Cholesky factorization
+    a = a.astype(dtype, order='C', copy=True)
+    ap = cupy.core._mat_ptrs(a)
+    lda, n = a.shape[-2:]
+    batch_size = int(numpy.prod(a.shape[:-2]))
+
+    handle = cupy.cuda.device.get_cusolver_handle()
+    uplo = cupy.cuda.cublas.CUBLAS_FILL_MODE_LOWER
+    dev_info = cupy.empty(batch_size, dtype=numpy.int32)
+
+    potrfBatched(handle, uplo, n, ap.data.ptr, lda, dev_info.data.ptr,
+                 batch_size)
+    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrfBatched, dev_info)
+
+    # Cholesky solve
+    b_shape = b.shape
+    b = b.conj().reshape(batch_size, n, -1).astype(dtype, order='C', copy=True)
+    bp = cupy.core._mat_ptrs(b)
+    ldb, nrhs = b.shape[-2:]
+    dev_info = cupy.empty(1, dtype=numpy.int32)
+
+    potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
+                 dev_info.data.ptr, batch_size)
+    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrsBatched, dev_info)
+
+    return b.conj().reshape(b_shape)
+
+@cupy.prof.TimeRangeDecorator("_posv")
+def _posv(a, b):
+    """Solve the linear equations A x = b via Cholesky factorization of A,
+    where A is a real symmetric or complex Hermitian positive-definite matrix.
+
+    If matrix ``A`` is not positive definite, Cholesky factorization fails
+    and it raises an error.
+
+    Note: For batch input, NRHS > 1 is not currently supported.
+
+    Args:
+        a (cupy.ndarray): Array of real symmetric or complex hermitian
+            matrices with dimension (..., N, N).
+        b (cupy.ndarray): right-hand side (..., N) or (..., N, NRHS).
+    Returns:
+        x (cupy.ndarray): The solution (shape matches b).
+    """
+
+    cupy.linalg._util._assert_cupy_array(a, b)
+    cupy.linalg._util._assert_nd_squareness(a)
+
+    if a.ndim > 2:
+        return _batch_posv(a, b)
+
+    dtype = numpy.promote_types(a.dtype, b.dtype)
+    dtype = numpy.promote_types(dtype, 'f')
+
+    if dtype == 'f':
+        potrf = cupy.cuda.cusolver.spotrf
+        potrf_bufferSize = cupy.cuda.cusolver.spotrf_bufferSize
+        potrs = cupy.cuda.cusolver.spotrs
+    elif dtype == 'd':
+        potrf = cupy.cuda.cusolver.dpotrf
+        potrf_bufferSize = cupy.cuda.cusolver.dpotrf_bufferSize
+        potrs = cupy.cuda.cusolver.dpotrs
+    elif dtype == 'F':
+        potrf = cupy.cuda.cusolver.cpotrf
+        potrf_bufferSize = cupy.cuda.cusolver.cpotrf_bufferSize
+        potrs = cupy.cuda.cusolver.cpotrs
+    elif dtype == 'D':
+        potrf = cupy.cuda.cusolver.zpotrf
+        potrf_bufferSize = cupy.cuda.cusolver.zpotrf_bufferSize
+        potrs = cupy.cuda.cusolver.zpotrs
+    else:
+        msg = ('dtype must be float32, float64, complex64 or complex128'
+               ' (actual: {})'.format(a.dtype))
+        raise ValueError(msg)
+
+    a = a.astype(dtype, order='F', copy=True)
+    lda, n = a.shape
+
+    handle = cupy.cuda.device.get_cusolver_handle()
+    uplo = cupy.cuda.cublas.CUBLAS_FILL_MODE_LOWER
+    dev_info = cupy.empty(1, dtype=numpy.int32)
+
+    worksize = potrf_bufferSize(handle, uplo, n, a.data.ptr, lda)
+    workspace = cupy.empty(worksize, dtype=dtype)
+
+    # Cholesky factorization
+    potrf(handle, uplo, n, a.data.ptr, lda, workspace.data.ptr,
+          worksize, dev_info.data.ptr)
+    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrf, dev_info)
+
+    b_shape = b.shape
+    b = b.reshape(n, -1).astype(dtype, order='F', copy=True)
+    ldb, nrhs = b.shape
+
+    # Solve: A * X = B
+    potrs(handle, uplo, n, nrhs, a.data.ptr, lda, b.data.ptr, ldb,
+          dev_info.data.ptr)
+    cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
+        potrs, dev_info)
+
+    return cupy.ascontiguousarray(b.reshape(b_shape))
+
+@cupy.prof.TimeRangeDecorator("cholesky_solve")
+def cholesky_solve(a, b):
+    return _posv(a, b)
+
+@cupy.prof.TimeRangeDecorator("clipped_eigh")
+def clipped_eigh(a, clip_scale=1e-14):
+    assert clip_scale >= 0
+    w, v = cupy.linalg.eigh(a)
+    #- clip eigenvalues relative to maximum eigenvalue
+    #- TODO: assuming w is sorted, can skip cupy.max and use the appropriate index
+    w = cupy.clip(w, a_min=clip_scale*cupy.max(w))
+    return w, v
+
+@cupy.prof.TimeRangeDecorator("compose_eigh")
+def compose_eigh(w, v):
+    return cupy.einsum('...ik,...k,...jk->...ij', v, w, v)
+
+@cupy.prof.TimeRangeDecorator("matrix_sqrt")
+def matrix_sqrt(a):
+    #- eigen decomposition
+    w, v = clipped_eigh(a)
+    #- compose sqrt from eigen decomposition
+    q = compose_eigh(cupy.sqrt(w), v)
+    return q
+
+@cupy.prof.TimeRangeDecorator("diag_block_matrix_sqrt")
+def diag_block_matrix_sqrt(a, block_size):
+    a_shape = a.shape
+    n, m = a_shape[-2:]
+    batch_size = numpy.prod(a_shape[:-2], dtype=int)
+    nblocks, remainder = divmod(n, block_size)
+    assert n == m
+    assert remainder == 0
+    #- flatten batch dimensions
+    a = a.reshape(batch_size, n, m)
+    #- eigen decomposition
+    w, v = clipped_eigh(a)
+    #- compose inverse from eigen decomposition
+    ainv = compose_eigh(1.0/w, v)
+    #- extract diagonal blocks
+    #- TODO: use a view of diagonal blocks instead of copy?
+    ainv_diag_blocks = cupy.empty(
+        (batch_size * nblocks, block_size, block_size),
+        dtype=a.dtype
+    )
+    for i in range(batch_size):
+        for j, s in enumerate(range(0, n, block_size)):
+            bs = slice(s, s + block_size)
+            ainv_diag_blocks[i*nblocks + j] = ainv[i, bs, bs]
+    #- eigen decomposition
+    w, v = clipped_eigh(ainv_diag_blocks)
+    #- compose inverse sqrt from eigen decomposition
+    q_diag_blocks = compose_eigh(cupyx.rsqrt(w), v)
+    #- insert block sqrts into result
+    #- TODO: is there a way to avoid this new alloc/copy?
+    q = cupy.zeros_like(a)
+    for i in range(batch_size):
+        for j, s in enumerate(range(0, n, block_size)):
+            bs = slice(s, s + block_size)
+            q[i, bs, bs] = q_diag_blocks[i*nblocks + j]
+    return q.reshape(a_shape)
+

--- a/py/gpu_specter/polynomial.py
+++ b/py/gpu_specter/polynomial.py
@@ -1,0 +1,56 @@
+import numpy
+
+from numba import cuda
+import cupy
+import cupy.prof
+
+@cuda.jit
+def _hermevander(x, deg, output_matrix):
+    i = cuda.blockIdx.x
+    _, j = cuda.grid(2)
+    _, stride = cuda.gridsize(2)
+    for j in range(j, x.shape[1], stride):
+        output_matrix[i][j][0] = 1
+        if deg > 0:
+            output_matrix[i][j][1] = x[i][j]
+            for k in range(2, deg + 1):
+                output_matrix[i][j][k] = output_matrix[i][j][k-1]*x[i][j] - output_matrix[i][j][k-2]*(k-1)
+
+@cupy.prof.TimeRangeDecorator("hermevander")
+def hermevander(x, deg):
+    """Temprorary wrapper that allocates memory and calls hermevander_gpu
+    """
+    if x.ndim == 1:
+        x = cupy.expand_dims(x, 0)
+    output = cupy.ndarray(x.shape + (deg+1,))
+    blocksize = 256
+    numblocks = (x.shape[0], (x.shape[1] + blocksize - 1) // blocksize)
+    _hermevander[numblocks, blocksize](x, deg, output)
+    cuda.synchronize()
+    return cupy.squeeze(output)
+
+@cuda.jit
+def _legvander(x, deg, output_matrix):
+    i = cuda.grid(1)
+    stride = cuda.gridsize(1)
+    for i in range(i, x.shape[0], stride):
+        output_matrix[i][0] = 1
+        output_matrix[i][1] = x[i]
+        for j in range(2, deg + 1):
+            output_matrix[i][j] = (output_matrix[i][j-1]*x[i]*(2*j - 1) - output_matrix[i][j-2]*(j - 1)) / j
+
+@cupy.prof.TimeRangeDecorator("legvander")
+def legvander(x, deg):
+    """Temporary wrapper that allocates memory and defines grid before calling legvander.
+    Probably won't be needed once cupy has the correpsponding legvander function.
+
+    Input: Same as cpu version of legvander
+    Output: legvander matrix, cupy.ndarray
+    """
+    x = cupy.array(x, copy=False)
+    output = cupy.ndarray((len(x), deg + 1))
+    blocksize = 256
+    numblocks = (len(x) + blocksize - 1) // blocksize
+    _legvander[numblocks, blocksize](x, deg, output)
+    cuda.synchronize()
+    return output

--- a/py/gpu_specter/test/test_extract.py
+++ b/py/gpu_specter/test/test_extract.py
@@ -36,7 +36,7 @@ class TestExtract(unittest.TestCase):
         nspec = 5
 
         cls.psferr = cls.psfdata['PSF'].meta['PSFERR']
-        cls.spots, cls.corners = get_spots(0, nspec, cls.wavelengths, cls.psfdata)
+        cls.spots, cls.corners, psfparams = get_spots(0, nspec, cls.wavelengths, cls.psfdata)
         cls.A4, cls.xyrange = projection_matrix(0, nspec, 0, nwave, cls.spots, cls.corners)
 
         phot = np.zeros((nspec, nwave))

--- a/py/gpu_specter/test/test_linalg.py
+++ b/py/gpu_specter/test/test_linalg.py
@@ -1,0 +1,78 @@
+import unittest
+import numpy as np
+
+try:
+    import cupy as cp
+    cupy_available = cp.is_available()
+
+    from gpu_specter.linalg import (
+        cholesky_solve,
+        matrix_sqrt,
+        diag_block_matrix_sqrt
+    )
+except ImportError:
+    cupy_available = False
+
+class TestLinalg(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_basics(self):
+        pass
+
+    @unittest.skipIf(not cupy_available, 'cupy not available')
+    def test_gpu_matrix_sqrt(self):
+        nblocks, block_size = 2, 3
+        n = nblocks * block_size
+        diagsqrt = 1 + np.arange(n)
+        diag = diagsqrt**2
+        a = np.diag(diag).astype(np.float32)
+        a_device = cp.asarray(a)
+
+        # test basic matrix sqrt
+        q_device = matrix_sqrt(a_device)
+        qdiag = np.diag(cp.asnumpy(q_device))
+        ok = np.allclose(qdiag, diagsqrt)
+        self.assertTrue(ok, f'{qdiag} != {diagsqrt}')
+
+    @unittest.skipIf(not cupy_available, 'cupy not available')
+    def test_gpu_diag_block_matrix_sqrt(self):
+        nblocks, block_size = 2, 3
+        n = nblocks * block_size
+        diagsqrt = 1 + np.arange(n)
+        diag = diagsqrt**2
+        a = np.diag(diag).astype(np.float32)
+        a_device = cp.asarray(a)
+
+        # test diag block matrix sqrt
+        q_device = diag_block_matrix_sqrt(a_device, block_size)
+        qdiag = np.diag(cp.asnumpy(q_device))
+        ok = np.allclose(qdiag, diagsqrt)
+        self.assertTrue(ok, f'{qdiag} != {diagsqrt}')
+
+    @unittest.skipIf(not cupy_available, 'cupy not available')
+    def test_gpu_cholesky_solve(self):
+
+        n = 10
+        diag = 1 + np.arange(n)
+        a = np.diag(diag).astype(dtype=np.float32)
+        b = np.ones(n).astype(dtype=np.float32)
+        x_device = cholesky_solve(cp.asarray(a), cp.asarray(b))
+        x = cp.asnumpy(x_device)
+
+        ok = np.allclose(x, 1.0/diag)
+        self.assertTrue(ok, f'{x} != {diag}')
+
+

--- a/py/gpu_specter/test/test_polynomial.py
+++ b/py/gpu_specter/test/test_polynomial.py
@@ -1,0 +1,51 @@
+import unittest
+import numpy as np
+
+try:
+    import cupy as cp
+    cupy_available = cp.is_available()
+except ImportError:
+    cupy_available = False
+
+class TestPolynomial(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_basics(self):
+        pass
+
+    @unittest.skipIf(not cupy_available, 'cupy not available')
+    def test_gpu_hermevander(self):
+        from numpy.polynomial.hermite_e import hermevander as numpy_hermevander
+        from gpu_specter.polynomial import hermevander as gpu_hermevander
+        x = np.array([-1, 0, 1])
+        result = numpy_hermevander(x, 3)
+        gpu_x = cp.array(x)
+        gpu_result = gpu_hermevander(gpu_x, 3)
+        ok = np.allclose(cp.asnumpy(gpu_result), result)
+        self.assertTrue(ok, f'{gpu_result} != {result}')
+
+
+    @unittest.skipIf(not cupy_available, 'cupy not available')
+    def test_gpu_legvander(self):
+        from numpy.polynomial.legendre import legvander as numpy_legvander
+        from gpu_specter.polynomial import legvander as gpu_legvander
+        x = np.array([-1, 0, 1])
+        result = numpy_legvander(x, 3)
+        gpu_x = cp.array(x)
+        gpu_result = gpu_legvander(gpu_x, 3)
+        ok = np.allclose(cp.asnumpy(gpu_result), result)
+        self.assertTrue(ok, f'{gpu_result} != {result}')
+        

--- a/py/gpu_specter/test/test_projection_matrix.py
+++ b/py/gpu_specter/test/test_projection_matrix.py
@@ -40,7 +40,7 @@ class TestProjectionMatrix(unittest.TestCase):
 
     def test_basics(self):
         wavelengths = np.arange(6000.0, 6050.0, 1.0)
-        spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
+        spots, corners, psfparams = get_spots(0, 25, wavelengths, self.psfdata)
         
         #- Projection matrix for a subset of spots and wavelenghts
         A4, (xmin, xmax, ymin, ymax) = projection_matrix(
@@ -57,7 +57,7 @@ class TestProjectionMatrix(unittest.TestCase):
     @unittest.skipIf(not gpu_available, 'gpu not available')
     def test_compare_gpu(self):
         wavelengths = np.arange(5990.0, 6060.0, 1.0)
-        spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
+        spots, corners, psfparams = get_spots(0, 25, wavelengths, self.psfdata)
 
         spots_gpu = cp.asarray(spots)
         corners_gpu = [cp.asarray(c) for c in corners]
@@ -88,7 +88,7 @@ class TestProjectionMatrix(unittest.TestCase):
         
         #- gpu_specter
         wavelengths = np.arange(5990.0, 6060.0, 1.0)
-        spots, corners = get_spots(0, 25, wavelengths, self.psfdata)
+        spots, corners, psfparams = get_spots(0, 25, wavelengths, self.psfdata)
 
         #- Load specter PSF
         psf = specter.psf.load_psf(self.psffile)

--- a/py/gpu_specter/test/test_spots.py
+++ b/py/gpu_specter/test/test_spots.py
@@ -46,7 +46,7 @@ class TestPSFSpots(unittest.TestCase):
 
     def test_basics(self):
         nspec = 50
-        spots, corners = get_spots(0, nspec, self.wavelengths, self.psfdata)
+        spots, corners, psfparams = get_spots(0, nspec, self.wavelengths, self.psfdata)
         cx, cy = corners
         
         #- Dimensions
@@ -88,10 +88,10 @@ class TestPSFSpots(unittest.TestCase):
     @unittest.skipIf(not gpu_available, 'gpu not available')
     def test_compare_gpu(self):
         for ispec in np.linspace(0, 499, 20).astype(int):
-            spots, corners = get_spots(ispec, 1, self.wavelengths, self.psfdata)
+            spots, corners, psfparams = get_spots(ispec, 1, self.wavelengths, self.psfdata)
             xc, yc = corners
 
-            spots_gpu, corners_gpu = gpu_get_spots(ispec, 1, self.wavelengths, self.psfdata)
+            spots_gpu, corners_gpu, psfparams_gpu = gpu_get_spots(ispec, 1, self.wavelengths, self.psfdata)
             xc_gpu, yc_gpu = corners_gpu
 
             # compare corners
@@ -109,7 +109,7 @@ class TestPSFSpots(unittest.TestCase):
         psf = specter.psf.load_psf(self.psffile)
 
         for ispec in np.linspace(0, 499, 20).astype(int):
-            spots, corners = get_spots(ispec, 1, self.wavelengths, self.psfdata)
+            spots, corners, psfparams = get_spots(ispec, 1, self.wavelengths, self.psfdata)
             xc, yc = corners
 
             ny, nx = spots.shape[2:4]


### PR DESCRIPTION
This PR adds support for extracting patches that partially extend beyond range of image. This PR originated as an attempt to resolve the intermittent zero flux issue #51 but that turns out to be an issue that has been fixed in package dependency.

Summary of other changes:

 * Add support for running desi-extract-exposure without mpi. 
 * Allows an existing wavelength array to be passed to extract_frame. 
 * Adds psfparams object to return tuple of get_spots.
 * Fix arguments passed to `_prepare_patch(...)` inside to `ex2d_padded(...)`. ex2d_padded has been superseded by ex2d_subbundle for gpu extractions but is still useful for comparison and debugging.