### PR TITLE
Use pixpad fraction padding by default

### DIFF
--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -417,7 +417,7 @@ def decompose_comm(comm=None, gpu=False, ranks_per_bundle=None):
 # @cupy.prof.TimeRangeDecorator("extract_frame")
 def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavestep=50, nsubbundles=1,
     model=None, regularize=0, psferr=None, comm=None, gpu=None, loglevel=None, timing=None, 
-    wavepad=10, pixpad_frac=0, batch_subbundle=True):
+    wavepad=12, pixpad_frac=0.8, batch_subbundle=True):
     """
     Extract 1D spectra from 2D image.
 

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -584,7 +584,7 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
             model=model,
             regularize=regularize,
             psferr=psferr,
-            pixpad_frac=0,
+            pixpad_frac=pixpad_frac,
         )
         if gpu:
             cp.cuda.nvtx.RangePop()

--- a/py/gpu_specter/extract/gpu.py
+++ b/py/gpu_specter/extract/gpu.py
@@ -726,13 +726,12 @@ def ex2d_subbundle(image, imageivar, patches, spots, corners, pixpad_frac, regul
     # finalize patch results
     cp.cuda.nvtx.RangePush('batch_finalize')
     results = list()
-    ndiag = spots.shape[2]//2
     for i, patch in enumerate(patches):
         result = _finalize_patch(
             batch_pixels[i], batch_ivar[i], batch_A4[i], batch_xyslice[i],
             batch_flux[i], batch_fluxivar[i], batch_resolution[i],
             patch.ispec-patch.bspecmin-specmin, patch.nspectra_per_patch,
-            patch.nwavestep, patch.wavepad, ndiag, psferr, patch, model=model
+            patch.nwavestep, patch.wavepad, patch.ndiag, psferr, patch, model=model
         )
         results.append( (patches[i], result) )
     cp.cuda.nvtx.RangePop()

--- a/py/gpu_specter/linalg.py
+++ b/py/gpu_specter/linalg.py
@@ -1,3 +1,6 @@
+"""This module provides functions for performing linear algebra operations.
+"""
+
 import numpy
 import cupy
 import cupy.prof

--- a/py/gpu_specter/mpi.py
+++ b/py/gpu_specter/mpi.py
@@ -1,3 +1,6 @@
+"""This module provides helpers classes for managing data movement when using MPI.
+"""
+
 # import cupy.prof
 
 class NoMPIComm(object):

--- a/py/gpu_specter/polynomial.py
+++ b/py/gpu_specter/polynomial.py
@@ -1,3 +1,6 @@
+"""This module provides functions for working with polynomial series using GPUs. Theses functions
+are based on ones provided by `numpy.polynomial`.
+"""
 import numpy
 
 from numba import cuda

--- a/py/gpu_specter/spex.py
+++ b/py/gpu_specter/spex.py
@@ -49,6 +49,10 @@ def parse(options=None):
     # parser.add_argument("--barycentric-correction", action="store_true", help="apply barycentric correction to wavelength")
     parser.add_argument("--async-io", action="store_true",
                         help="use asynchronous read/write mpi comm")
+    parser.add_argument("--pixpad-frac", type=float, required=False, default=0.8,
+                        help="Fraction of pixel padding to apply to extraction patch")
+    parser.add_argument("--wavepad", type=int, required=False, default=12,
+                        help="Number of wavelength bins to pad on boths end of extraction patch")
     args = None
     if options is None:
         args = parser.parse_args()
@@ -151,6 +155,8 @@ def main_gpu_specter(args=None, comm=None, timing=None):
             comm.extract_comm,                 # mpi parameters
             args.gpu,                          # gpu parameters
             args.loglevel,                     # log
+            wavepad=args.wavepad,
+            pixpad_frac=args.pixpad_frac,
         )
 
         #- Pass other input data through for output

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -164,15 +164,10 @@ class TestCore(unittest.TestCase):
         norm = np.sqrt(1.0/frame_spex['specivar'] + 1.0/frame_specter['ivar'])
         pull = (diff/norm).ravel()
 
-        #- require that 99% of results are consistent to better than 0.01*sigma
-        frac = np.count_nonzero(np.abs(pull)<0.01) / len(pull)
-        # self.assertLess(frac, 0.99)
-
-        #- previous test; I'm not sure this makes sense
-        #- this is even more correct than the test commented out above ;) 
+        #- Require that >99% of the pull values are consistent to
+        #- better than 0.01*sigma
         pull_threshold = 0.01
         pull_fraction = np.average(np.abs(pull) < pull_threshold)
-        self.assertEqual(pull_fraction, frac) #- just to prove pull_fraction == frac
         self.assertGreaterEqual(pull_fraction, 0.99)
 
         #- require that the largest deviation is within 5% of a sigma

--- a/py/gpu_specter/test/test_core.py
+++ b/py/gpu_specter/test/test_core.py
@@ -166,15 +166,17 @@ class TestCore(unittest.TestCase):
 
         #- require that 99% of results are consistent to better than 0.01*sigma
         frac = np.count_nonzero(np.abs(pull)<0.01) / len(pull)
-        self.assertLess(frac, 0.99)
+        # self.assertLess(frac, 0.99)
+
+        #- previous test; I'm not sure this makes sense
+        #- this is even more correct than the test commented out above ;) 
+        pull_threshold = 0.01
+        pull_fraction = np.average(np.abs(pull) < pull_threshold)
+        self.assertEqual(pull_fraction, frac) #- just to prove pull_fraction == frac
+        self.assertGreaterEqual(pull_fraction, 0.99)
 
         #- require that the largest deviation is within 5% of a sigma
         self.assertLess(np.max(np.abs(pull)), 0.05)
-
-        #- previous test; I'm not sure this makes sense
-        # pull_threshold = 0.01
-        # pull_fraction = np.average(np.abs(pull).ravel() < pull_threshold)
-        # self.assertGreaterEqual(pull_fraction, 0.95)
 
     @unittest.skipIf(not gpu_available, 'gpu not available')
     def test_compare_gpu(self):


### PR DESCRIPTION
This PR updates the default values for `wavepad` and `pixpad_frac` to be similar to default values used in specter. Note that the wave padding in gpu_specter is specified using a fixed integer value rather than a relative fraction. 

I also added a few short docstrings for good karma to balance out the snarky update I made to the `test_compare_specter` unit test in `test_core.py`.

It's still not passing the largest deviation < 5% sigma test but it will be interesting to see how the self-consistency plots change @sbailey 

```
> srun -n 1 --cpu-bind=cores pytest py/gpu_specter
============================= test session starts ==============================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /global/u2/d/dmargala/debug-specter/gpu_specter
plugins: anyio-2.2.0
collected 32 items

py/gpu_specter/test/test_core.py .F..                                    [ 12%]
py/gpu_specter/test/test_extract.py ...........                          [ 46%]
py/gpu_specter/test/test_linalg.py ....                                  [ 59%]
py/gpu_specter/test/test_polynomial.py ...                               [ 68%]
py/gpu_specter/test/test_projection_matrix.py ...                        [ 78%]
py/gpu_specter/test/test_psfcoeff.py ....                                [ 90%]
py/gpu_specter/test/test_spots.py ...                                    [100%]

=================================== FAILURES ===================================
...
        #- require that the largest deviation is within 5% of a sigma
>       self.assertLess(np.max(np.abs(pull)), 0.05)
E       AssertionError: 0.06892567444831484 not less than 0.05

py/gpu_specter/test/test_core.py:179: AssertionError
=========================== short test summary info ============================
FAILED py/gpu_specter/test/test_core.py::TestCore::test_compare_specter - Ass...
=================== 1 failed, 31 passed in 71.18s (0:01:11) ====================
```