### PR TITLE
clean up serial/parallel io helper classes

### DIFF
--- a/bin/desi-extract-exposure
+++ b/bin/desi-extract-exposure
@@ -16,10 +16,15 @@ import glob
 import os
 import sys
 
-import cupy as cp
+try:
+    import cupy as cp
+    cupy_available = True
+except:
+    cupy_available = False
 
 from desispec.scripts import extract
-from gpu_specter.mpi import SyncIOComm, AsyncIOComm
+from gpu_specter.mpi import (
+    NoMPIIOCoordinator, SerialIOCoordinator, ParallelIOCoordinator)
 import gpu_specter.spex
 
 #- Parse args before initializing MPI so that --help will work anywhere
@@ -91,6 +96,7 @@ else:
 
 group = node
 if args.gpu:
+    assert cupy_available, f"arg.gpu specified but failed to import cupy"
     gpus = os.environ.get("CUDA_VISIBLE_DEVICES", "")
     group += ":" + gpus
 
@@ -108,9 +114,9 @@ if comm is not None:
     group_comm = comm.Split(color=group_index, key=group_rank)
 
     if args.async_io:
-        group_comm = AsyncIOComm(group_comm)
+        coordinator = ParallelIOCoordinator(group_comm)
     else:
-        group_comm = SyncIOComm(group_comm)
+        coordinator = SerialIOCoordinator(group_comm)
 else:
     ngroups = 1
     group_index = 0
@@ -118,6 +124,7 @@ else:
     group_size = 1
     group_comm = None
     groups = [group, ]
+    coordinator = NoMPIIOCoordinator()
 
 if rank == 0:
     print(f"Splitting {size} ranks into {ngroups} groups of {group_size}")
@@ -245,7 +252,7 @@ for camera in group_cameras:
 
     #- Perform extraction
     cp.cuda.nvtx.RangePush(f'{rank}:main_gpu_specter')
-    engine.main_gpu_specter(cmd_args, comm=group_comm, timing=timing)
+    engine.main_gpu_specter(cmd_args, coordinator=coordinator, timing=timing)
     cp.cuda.nvtx.RangePop() # main_gpu_specter
 
     #- Save timing events from extraction

--- a/py/gpu_specter/mpi.py
+++ b/py/gpu_specter/mpi.py
@@ -1,4 +1,17 @@
 """This module provides helpers classes for managing data movement when using MPI.
+
+Example usage:
+
+# no mpi
+python py/gpu_specter/mpi.py
+
+# mpi: serial io
+mpirun -n 2 python py/gpu_specter/mpi.py --mpi
+
+# mpi: parallel io
+# parallel io requires at least 3 MPI ranks (2 for IO and at least one for processing)
+mpirun -n 4 python py/gpu_specter/mpi.py --mpi --async-io
+
 """
 
 from abc import ABC, abstractmethod

--- a/py/gpu_specter/mpi.py
+++ b/py/gpu_specter/mpi.py
@@ -1,202 +1,329 @@
 """This module provides helpers classes for managing data movement when using MPI.
 """
 
-# import cupy.prof
+from abc import ABC, abstractmethod
 
-class NoMPIComm(object):
-    READ_RANK = 0
-    WRITE_RANK = 0
-    EXTRACT_ROOT = 0
+
+class AbstractIOCoordinator(ABC):
+    """Abstract base class for coordinating read/process/write steps of a program."""
+    @classmethod
+    def is_reader(cls, rank):
+        return rank == cls._read_rank
+
+    @classmethod
+    def is_writer(cls, rank):
+        return rank == cls._write_rank
+
+    @classmethod
+    def is_worker_root(cls, rank):
+        return rank == cls._worker_root
+
+    @classmethod
+    def is_worker(cls, rank):
+        return rank >= cls._worker_root
+
+    @abstractmethod
+    def read(self, func, payload):
+        """Read input via func()."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def process(self, func, payload):
+        """Returns the result of func()."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def write(self, func, payload):
+        """Writes output by calling func(payload)."""
+        raise NotImplementedError()
+
+
+class NoMPIIOCoordinator(AbstractIOCoordinator):
+    _read_rank = 0
+    _write_rank = 0
+    _worker_root = 0
 
     def __init__(self):
+        """A NoMPIIOCoordinator coordinates read/process/write steps of a program when run without MPI."""
         self.comm = None
         self.rank = 0
         self.size = 1
+        self.work_comm = None
 
-        self.extract_comm = None
+    def read(self, func, payload):
+        """Reads input via func().
 
-    def is_extract_rank(self):
-        return True
+        Args:
+            func: a callable with no arguments.
+            payload: a dummy value matching the return signature of func.
 
-    def is_extract_root(self):
-        return True
-
-    def read(self, func, data):
+        Returns:
+            result: the result of func().
+        """
         return func()
 
-    def write(self, func, data):
-        func(data)
-
-class SyncIOComm(object):
-    READ_RANK = 0
-    WRITE_RANK = 0
-    EXTRACT_ROOT = 0
-
-    def __init__(self, comm):
-        """Synchronous communication/extraction manager.
+    def process(self, func, payload):
+        """Returns the result of func().
 
         Args:
-            comm: the parent MPI communicator. Must have at least 1 rank
+            func: a callable with no arguments.
+            payload: a dummy value matching the return signature of func.
+
+        Returns:
+            result: the result of func().
+        """
+        return func()
+
+    def write(self, func, payload):
+        """Writes output by calling func(payload).
+
+        Args:
+            func: a callable that takes payload as an argument.
+            payload: the argument to pass to func.
+
+        Rertuns:
+            result: the result of func(payload).
+        """
+        return func(payload)
+
+
+class SerialIOCoordinator(AbstractIOCoordinator):
+    _read_rank = 0
+    _write_rank = 0
+    _worker_root = 0
+
+    def __init__(self, comm):
+        """A SerialIOCoordinator coordinates read/process/write steps of a program using MPI.
+        The read and write steps will performed by the root rank of the provided MPI communicator.
+        All ranks will peform the process step.
+
+        Args:
+            comm: an MPI communicator.
         """
         self.comm = comm
         self.rank = comm.rank
         self.size = comm.size
+        self.work_comm = comm
 
-        self.extract_comm = comm
-
-    def is_extract_rank(self):
-        return self.comm.rank >= SyncIOComm.EXTRACT_ROOT
-
-    def is_extract_root(self):
-        return self.comm.rank == SyncIOComm.EXTRACT_ROOT
-
-    # @cupy.prof.TimeRangeDecorator("SyncIOComm.read")
-    def read(self, func, data):
-        if self.comm.rank == SyncIOComm.READ_RANK:
-            data = func()
-        return data
-
-    # @cupy.prof.TimeRangeDecorator("SyncIOComm.write")
-    def write(self, func, data):
-        if self.comm.rank == SyncIOComm.WRITE_RANK:
-            func(data)
-
-class AsyncIOComm(object):
-    READ_RANK = 0
-    WRITE_RANK = 1
-    EXTRACT_ROOT = 2
-
-    def __init__(self, comm):
-        """Asynchronous communication/extraction manager.
+    def read(self, func, payload):
+        """Reads input via func() on reader rank. Meanwhile, other ranks proceed and are not blocked.
 
         Args:
-            comm: the parent MPI communicator. Must have at least 3 ranks
+            func: a callable with no arguments.
+            payload: a dummy value matching the return signature of func.
+
+        Returns:
+            result: all ranks return dummy payload except the reader rank which returns
+                the result of func().
+        """
+        if SerialIOCoordinator.is_reader(self.rank):
+            result = func()
+        else:
+            result = payload
+        return result
+
+    def process(self, func, payload):
+        """Returns the result of func(). Non-worker ranks return the provided dummy payload.
+
+        Args:
+            func: a callable with no arguments.
+            payload: a dummy value matching the return signature of func.
+
+        Returns:
+            result: workers return the result of func(). Non-worker ranks return the provided dummy payload.
+        """
+        if SerialIOCoordinator.is_worker(self.rank):
+            result = func()
+        else:
+            result = payload
+        return result
+
+    def write(self, func, payload):
+        """Writes output by calling func(payload) from the writer rank. Meanwhile, other ranks
+        proceed and are not blocked.
+
+        Args:
+            func: a callable that takes payload as an argument.
+            payload: on writer rank, the argument to pass to func. otherwise, a dummy
+                value matching the return signature of func.
+
+        Rertuns:
+            result: all ranks return dummy payload except the writer rank, which returns
+                the result of func(payload).
+        """
+        if SerialIOCoordinator.is_writer(self.rank):
+            result = func(payload)
+        else:
+            result = payload
+        return result
+
+
+class ParallelIOCoordinator(AbstractIOCoordinator):
+    _read_rank = 0
+    _write_rank = 1
+    _worker_root = 2
+
+    def __init__(self, comm):
+        """
+        A ParallelIOCoordinator coordinates read/process/write steps of a program using MPI.
+        The read and write steps are performed on dedicated ranks which allows for parallel compute and IO
+        when processing multiple tasks in series. The read and write steps between tasks will be interleaved
+        with processing.
+
+        Args:
+            comm: an MPI communicator.
         """
         self.comm = comm
         self.rank = comm.rank
         self.size = comm.size
-        assert self.size >= 3
+        assert self.size >= 3, "ParallelIOCoordinator requires at least 3 MPI ranks"
 
-        # Initialize extraction comm
-        # READ/WRITE ranks have MPI_COMM_NULL?
-        self.extract_comm = None
-        self.extract_group = self.comm.group.Excl(
-            [AsyncIOComm.READ_RANK, AsyncIOComm.WRITE_RANK])
-        if self.is_extract_rank():
-            self.extract_comm = comm.Create_group(self.extract_group)
+        # Initialize work comm
+        self.work_comm = None
+        work_group = self.comm.group.Excl(
+            [ParallelIOCoordinator._read_rank, ParallelIOCoordinator._write_rank]
+        )
+        if ParallelIOCoordinator.is_worker(self.rank):
+            self.work_comm = comm.Create_group(work_group)
 
-    def is_extract_rank(self):
-        """Returns True if this MPI rank is part of the extraction group.
-        Otherwise returns False.
-        """
-        return self.comm.rank >= AsyncIOComm.EXTRACT_ROOT
-
-    def is_extract_root(self):
-        return self.comm.rank == AsyncIOComm.EXTRACT_ROOT
-
-    # @cupy.prof.TimeRangeDecorator("AsyncIOComm.read")
-    def read(self, func, data):
-        """READ_RANK will call `func` and send the result to EXTRACT_ROOT.
-        EXTRACT_ROOT returns the result from READ_RANK. All other ranks return 
-        the provided default `data`.
+    def read(self, func, payload):
+        """Reads input via func() on reader rank and sends the result to worker root. Meanwhile,
+        other ranks proceed and are not blocked. The worker root will proceed after receiving.
 
         Args:
-            func (method): function to be called by READ_RANK that reads input data.
-            data: default placeholder for data. mostly here for symmetry with `write(...)`
+            func: a callable with no arguments.
+            payload: a dummy value matching the return signature of func.
 
-        Returns: 
-            data: either the provided default data or data returned by func on EXTRACT_ROOT/READ_RANK
+        Returns:
+            result: all ranks return dummy payload except the worker root which returns
+                the result of func().
         """
-        if self.comm.rank == AsyncIOComm.READ_RANK:
-            data = func()
-            self.comm.send(data, dest=AsyncIOComm.EXTRACT_ROOT, tag=1)
-        elif self.comm.rank == AsyncIOComm.EXTRACT_ROOT:
-            data = self.comm.recv(source=AsyncIOComm.READ_RANK, tag=1)
-        return data
+        if ParallelIOCoordinator.is_reader(self.rank):
+            # read input via func()
+            result = func()
+            # send the result to worker root
+            self.comm.send(result, dest=ParallelIOCoordinator._worker_root, tag=1)
+            # dummy payload passes through
+            result = payload
+        elif ParallelIOCoordinator.is_worker_root(self.rank):
+            # receive the result from reader
+            result = self.comm.recv(source=ParallelIOCoordinator._read_rank, tag=1)
+        else:
+            # dummy payload passes through
+            result = payload
+        return result
 
-    # @cupy.prof.TimeRangeDecorator("AsyncIOComm.write")
-    def write(self, func, data):
-        """EXTRACT_ROOT sends `data` to WRITE_RANK. WRITE_RANK calls `func` to
-        write `data`. This is a no-op for all other ranks.
+    def process(self, func, payload):
+        """Returns the result of func(). Non-worker ranks return the provided dummy payload.
 
         Args:
-            func (method): function that writes `data`.
-            data: the data to be written by `func`.
+            func: a callable with no arguments.
+            payload: a dummy value matching the return signature of func.
+
+        Returns:
+            result: workers return the result of func(). Non-worker ranks return the provided dummy payload.
         """
-        if self.comm.rank == AsyncIOComm.EXTRACT_ROOT:
-            self.comm.send(data, dest=AsyncIOComm.WRITE_RANK, tag=2)
-        elif self.comm.rank == AsyncIOComm.WRITE_RANK:
-            data = self.comm.recv(source=AsyncIOComm.EXTRACT_ROOT, tag=2)
-            func(data)
+        if ParallelIOCoordinator.is_worker(self.rank):
+            result = func()
+        else:
+            result = payload
+        return result
 
-
-class AnotherAsyncIOComm(object):
-    READ_RANK = 0
-    WRITE_RANK = 1
-    EXTRACT_READ_RANK = 2
-    EXTRACT_WRITE_RANK = 3
-
-
-    def __init__(self, comm):
-        """Asynchronous communication/extraction manager.
+    def write(self, func, payload):
+        """Writes output by sending payload from worker root to writer rank. The writer rank will then
+        call the provided func with the payload argument to write output. Meanwhile, other ranks
+        proceed and are not blocked. The worker root will proceed after sending payload.
 
         Args:
-            comm: the parent MPI communicator. Must have at least 4 ranks
+            func: a callable that takes payload as an argument.
+            payload: on worker_root, the argument to pass to func. otherwise, a dummy
+                value matching the return signature of func.
+
+        Rertuns:
+            result: all ranks return dummy payload except the write_rank which returns
+                the result of func(payload).
         """
-        self.comm = comm
-        self.rank = comm.rank
-        self.size = comm.size
-        assert self.size >= 4
+        if ParallelIOCoordinator.is_worker_root(self.rank):
+            # receive the dummy payload from writer
+            result = self.comm.recv(source=ParallelIOCoordinator._write_rank, tag=2)
+            # send the actual payload to writer
+            self.comm.send(payload, dest=ParallelIOCoordinator._write_rank, tag=3)
+        elif ParallelIOCoordinator.is_writer(self.rank):
+            # send the dummy payload to worker root
+            self.comm.send(payload, dest=ParallelIOCoordinator._worker_root, tag=2)
+            # receive actual payload from worker root
+            payload = self.comm.recv(source=ParallelIOCoordinator._worker_root, tag=3)
+            # call func with payload
+            result = func(payload)
+        else:
+            # dummy payload passes through
+            result = payload
+        return result
 
-        # Initialize extraction comm
-        # READ/WRITE ranks have MPI_COMM_NULL?
-        self.extract_comm = None
-        self.extract_group = self.comm.group.Excl(
-            [AnotherAsyncIOComm.READ_RANK, AnotherAsyncIOComm.WRITE_RANK])
-        if self.is_extract_rank():
-            self.extract_comm = comm.Create_group(self.extract_group)
 
-    def is_extract_rank(self):
-        """Returns True if this MPI rank is part of the extraction group.
-        Otherwise returns False.
-        """
-        return self.comm.rank >= AnotherAsyncIOComm.EXTRACT_READ_RANK
+def example_program():
+    """This function demonstrates how to use the IOCoordinator classes."""
+    import argparse
 
-    def is_extract_root(self):
-        # WIP: what should the extract root be in this case?
-        raise NotImplementedError()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("--mpi", action="store_true", help="use mpi")
+    parser.add_argument("--async-io", action="store_true", help="async io")
+    args = parser.parse_args()
 
-    # @cupy.prof.TimeRangeDecorator("AnotherAsyncIOComm.read")
-    def read(self, func, data):
-        """READ_RANK will call `func` and send the result to EXTRACT_ROOT.
-        EXTRACT_ROOT returns the result from READ_RANK. All other ranks return 
-        the provided default `data`.
+    # initialize IO coordinator based on arguments
+    if args.mpi:
+        from mpi4py import MPI
 
-        Args:
-            func (method): function to be called by READ_RANK that reads input data.
-            data: default placeholder for data. mostly here for symmetry with `write(...)`
+        if args.async_io:
+            coordinator = ParallelIOCoordinator(MPI.COMM_WORLD)
+        else:
+            coordinator = SerialIOCoordinator(MPI.COMM_WORLD)
+    else:
+        coordinator = NoMPIIOCoordinator()
+    rank, size = coordinator.rank, coordinator.size
 
-        Returns: 
-            data: either the provided default data or data returned by func on EXTRACT_ROOT/READ_RANK
-        """
-        if self.comm.rank == AnotherAsyncIOComm.READ_RANK:
-            data = func()
-            self.comm.send(data, dest=AnotherAsyncIOComm.EXTRACT_READ_RANK, tag=1)
-        elif self.comm.rank == AnotherAsyncIOComm.EXTRACT_READ_RANK:
-            data = self.comm.recv(source=AnotherAsyncIOComm.READ_RANK, tag=1)
-        return data
+    # define example read/process/write functions
+    def generate_numbers(task_index):
+        return [task_index for i in range(10)]
 
-    # @cupy.prof.TimeRangeDecorator("AnotherAsyncIOComm.write")
-    def write(self, func, data):
-        """EXTRACT_ROOT sends `data` to WRITE_RANK. WRITE_RANK calls `func` to
-        write `data`. This is a no-op for all other ranks.
+    def distributed_sum(numbers, comm):
+        # broadcast data
+        if comm is not None:
+            numbers = comm.bcast(numbers, root=0)
+            numbers = numbers[comm.rank :: comm.size]
+        # each rank computes a subtotal
+        subtotal = sum(numbers)
+        # gather subtotals
+        if comm is not None:
+            subtotals = comm.gather(subtotal, root=0)
+        else:
+            subtotals = [
+                subtotal,
+            ]
+        # combine subtotals
+        if comm is not None and comm.rank > 0:
+            result = None
+        else:
+            result = sum(subtotals)
+        return result
 
-        Args:
-            func (method): function that writes `data`.
-            data: the data to be written by `func`.
-        """
-        if self.comm.rank == AnotherAsyncIOComm.EXTRACT_ROOT:
-            self.comm.send(data, dest=AnotherAsyncIOComm.EXTRACT_WRITE_RANK, tag=2)
-        elif self.comm.rank == AnotherAsyncIOComm.EXTRACT_WRITE_RANK:
-            data = self.comm.recv(source=AnotherAsyncIOComm.EXTRACT_ROOT, tag=2)
-            func(data)
+    def print_result(task_index, result):
+        print(f"{rank=} {task_index=} {result=}")
+
+    # iterate over tasks
+    for task_index in range(5):
+        # generate data
+        numbers = coordinator.read(lambda: generate_numbers(task_index), None)
+        # distributed_sum
+        result = coordinator.process(
+            lambda: distributed_sum(numbers, coordinator.work_comm), None
+        )
+        # print result
+        coordinator.write(lambda result: print_result(task_index, result), result)
+
+    if coordinator.comm is not None:
+        coordinator.comm.barrier()
+
+
+if __name__ == "__main__":
+    example_program()


### PR DESCRIPTION
This PR makes a few changes to clean up the serial/parallel io helper classes. The classes help coordinate the read/process/write steps in a typical use case. To make that more clear, I added a `process` method to each of the classes so that they all have a `read`, `process`, and `write` method now. I also updated the names of the classes to reduce confusion with MPI communicator objects:

`NoMPIComm` -> `NoMPIIOCoordinator`
`SyncIOComm` -> `SerialIOCoordinator`
`AsyncIOComm` -> `ParallelIOCoordinator`

There is now an example program that demonstrates how to use the classes. To run the example using each of the three coordinators:


```bash
# no mpi
python py/gpu_specter/mpi.py

# mpi: serial io
mpirun -n 2 python py/gpu_specter/mpi.py --mpi

# mpi: parallel io
mpirun -n 4 python py/gpu_specter/mpi.py --mpi --async-io
```
